### PR TITLE
chore: add `onColumnMove` prop

### DIFF
--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -126,6 +126,7 @@ interface Props {
   }): React.CSSProperties;
   wrapperStyle?(args: { index: number }): React.CSSProperties;
   onItemMove(result: MovedItemState): void;
+  onColumnMove?(result: { newIndex: number; columnId: UniqueIdentifier }): void;
   itemCount?: number;
   items?: Items;
   handle?: boolean;
@@ -147,7 +148,7 @@ export function KanbanBoard({
   itemCount = 3,
   cancelDrop,
   columns,
-  handle = false,
+  handle = true,
   items: initialItems,
   containerStyle,
   coordinateGetter = multipleContainersCoordinateGetter,
@@ -161,6 +162,7 @@ export function KanbanBoard({
   vertical = false,
   scrollable,
   onItemMove,
+  onColumnMove,
 }: Props) {
   const [items, setItems] = useState<Items>(
     () =>
@@ -378,12 +380,10 @@ export function KanbanBoard({
       }}
       onDragEnd={({ active, over }) => {
         if (active.id in items && over?.id) {
-          setContainers((containers) => {
-            const activeIndex = containers.indexOf(active.id);
-            const overIndex = containers.indexOf(over.id);
-
-            return arrayMove(containers, activeIndex, overIndex);
-          });
+          const activeIndex = containers.indexOf(active.id);
+          const overIndex = containers.indexOf(over.id);
+          onColumnMove?.({ newIndex: overIndex, columnId: active.id });
+          setContainers((containers) => arrayMove(containers, activeIndex, overIndex));
           return;
         }
 

--- a/src/preview/main.tsx
+++ b/src/preview/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import { KanbanBoard } from "../components/KanbanBoard";
 
 function App() {
-  return <KanbanBoard handle onItemMove={(v) => console.log(v)} trashable />;
+  return <KanbanBoard onItemMove={(v) => console.log(v)} onColumnMove={(v) => console.log(v)} />;
 }
 
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
It exposes a prop to keep track of the column-reorder changes. Additionally, it makes the `handle` prop `true` by default according to our needs.