### PR TITLE
chore: change the kanban board contract

### DIFF
--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -1,11 +1,11 @@
-import React, {useEffect} from 'react';
-import classNames from 'classnames';
-import type {DraggableSyntheticListeners} from '@dnd-kit/core';
-import type {Transform} from '@dnd-kit/utilities';
+import React, { useEffect } from "react";
+import classNames from "classnames";
+import type { DraggableSyntheticListeners } from "@dnd-kit/core";
+import type { Transform } from "@dnd-kit/utilities";
 
-import {Handle, Remove} from './components';
+import { Handle, Remove } from "./components";
 
-import styles from './Item.module.css';
+import styles from "./Item.module.css";
 
 export interface Props {
   dragOverlay?: boolean;
@@ -24,8 +24,10 @@ export interface Props {
   transition?: string | null;
   wrapperStyle?: React.CSSProperties;
   value: React.ReactNode;
+  content: string;
   onRemove?(): void;
   renderItem?(args: {
+    content: string;
     dragOverlay: boolean;
     dragging: boolean;
     sorting: boolean;
@@ -34,9 +36,9 @@ export interface Props {
     listeners: DraggableSyntheticListeners;
     ref: React.Ref<HTMLElement>;
     style: React.CSSProperties | undefined;
-    transform: Props['transform'];
-    transition: Props['transition'];
-    value: Props['value'];
+    transform: Props["transform"];
+    transition: Props["transition"];
+    value: Props["value"];
   }): React.ReactElement;
 }
 
@@ -62,6 +64,7 @@ export const Item = React.memo(
         transform,
         value,
         wrapperStyle,
+        content,
         ...props
       },
       ref
@@ -71,10 +74,10 @@ export const Item = React.memo(
           return;
         }
 
-        document.body.style.cursor = 'grabbing';
+        document.body.style.cursor = "grabbing";
 
         return () => {
-          document.body.style.cursor = '';
+          document.body.style.cursor = "";
         };
       }, [dragOverlay]);
 
@@ -91,6 +94,7 @@ export const Item = React.memo(
           transform,
           transition,
           value,
+          content,
         })
       ) : (
         <li
@@ -103,23 +107,13 @@ export const Item = React.memo(
           style={
             {
               ...wrapperStyle,
-              transition: [transition, wrapperStyle?.transition]
-                .filter(Boolean)
-                .join(', '),
-              '--translate-x': transform
-                ? `${Math.round(transform.x)}px`
-                : undefined,
-              '--translate-y': transform
-                ? `${Math.round(transform.y)}px`
-                : undefined,
-              '--scale-x': transform?.scaleX
-                ? `${transform.scaleX}`
-                : undefined,
-              '--scale-y': transform?.scaleY
-                ? `${transform.scaleY}`
-                : undefined,
-              '--index': index,
-              '--color': color,
+              transition: [transition, wrapperStyle?.transition].filter(Boolean).join(", "),
+              "--translate-x": transform ? `${Math.round(transform.x)}px` : undefined,
+              "--translate-y": transform ? `${Math.round(transform.y)}px` : undefined,
+              "--scale-x": transform?.scaleX ? `${transform.scaleX}` : undefined,
+              "--scale-y": transform?.scaleY ? `${transform.scaleY}` : undefined,
+              "--index": index,
+              "--color": color,
             } as React.CSSProperties
           }
           ref={ref}
@@ -139,11 +133,9 @@ export const Item = React.memo(
             {...props}
             tabIndex={!handle ? 0 : undefined}
           >
-            {value}
+            {content}
             <span className={styles.Actions}>
-              {onRemove ? (
-                <Remove className={styles.Remove} onClick={onRemove} />
-              ) : null}
+              {onRemove ? <Remove className={styles.Remove} onClick={onRemove} /> : null}
               {handle ? <Handle {...handleProps} {...listeners} /> : null}
             </span>
           </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./components/KanbanBoard";
+export * from "./utils/item-state-mutations";

--- a/src/preview/main.tsx
+++ b/src/preview/main.tsx
@@ -1,9 +1,31 @@
-import { StrictMode } from "react";
+import { StrictMode, useCallback, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { KanbanBoard } from "../components/KanbanBoard";
+import { Data, KanbanBoard } from "../components/KanbanBoard";
+import { updateColumnItems } from "../utils/item-state-mutations";
 
 function App() {
-  return <KanbanBoard onItemMove={(v) => console.log(v)} onColumnMove={(v) => console.log(v)} />;
+  const [items, setItems] = useState<Data>([
+    {
+      id: "1",
+      name: "A",
+      items: [{ id: "12", name: "A2" }],
+    },
+  ]);
+
+  const addNewItemToColumn = useCallback(() => {
+    const updateItems = updateColumnItems(items, "1", (ci) => [
+      ...ci,
+      { id: Math.random().toString(), name: Math.random().toString() },
+    ]);
+    setItems(updateItems);
+  }, [items]);
+
+  return (
+    <>
+      <KanbanBoard data={items} onItemMove={(v) => console.log(v)} onColumnMove={(v) => console.log(v)} minimal />
+      <button onClick={addNewItemToColumn}>Add item to column externally</button>
+    </>
+  );
 }
 
 createRoot(document.getElementById("root")!).render(

--- a/src/utils/item-state-mutations.ts
+++ b/src/utils/item-state-mutations.ts
@@ -1,0 +1,41 @@
+import { Data, DataItem } from "../components/KanbanBoard";
+
+export function updateColumnItems(items: Data, columnId: string, updateFn: (currentState: DataItem[]) => DataItem[]) {
+  return items.map((column) => {
+    if (column.id === columnId) {
+      return {
+        ...column,
+        items: updateFn(column.items),
+      };
+    }
+    return column;
+  });
+}
+
+export function removeColumnItem(items: Data, columnId: string, itemId: string) {
+  return items.map((column) => {
+    if (column.id === columnId) {
+      return {
+        ...column,
+        items: column.items.filter((item) => item.id !== itemId),
+      };
+    }
+    return column;
+  });
+}
+
+export function removeColumn(items: Data, columnId: string) {
+  return items.filter((column) => column.id !== columnId);
+}
+
+export function updateColumnName(items: Data, columnId: string, newName: string) {
+  return items.map((column) => {
+    if (column.id === columnId) {
+      return {
+        ...column,
+        name: newName,
+      };
+    }
+    return column;
+  });
+}


### PR DESCRIPTION
Before, it received only IDs or strings, which worked as the UI value and the internal id. In a real environment, we need to keep an ID and a name separately per item. This PR basically does that. It receives an array of columns that gets the `id`, `name`, and its `items`.  While this change from maps to arrays might affect complexity from `O(1)` to `O(n)` for lookups. In this case, we receive the contract as an array to make DevEx not complicated and convert that data into maps for keeping O(1) lookups. We'll see how it works.