### PR TITLE
chore: remove the map-based adapter

### DIFF
--- a/src/preview/main.tsx
+++ b/src/preview/main.tsx
@@ -1,14 +1,19 @@
 import { StrictMode, useCallback, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { Data, KanbanBoard } from "../components/KanbanBoard";
+import { Items, KanbanBoard } from "../components/KanbanBoard";
 import { updateColumnItems } from "../utils/item-state-mutations";
 
 function App() {
-  const [items, setItems] = useState<Data>([
+  const [items, setItems] = useState<Items>([
     {
       id: "1",
       name: "A",
       items: [{ id: "12", name: "A2" }],
+    },
+    {
+      id: "21",
+      name: "A2212",
+      items: [{ id: "12asdasda", name: "asA2" }],
     },
   ]);
 
@@ -20,9 +25,16 @@ function App() {
     setItems(updateItems);
   }, [items]);
 
+  console.log(items);
+
   return (
     <>
-      <KanbanBoard data={items} onItemMove={(v) => console.log(v)} onColumnMove={(v) => console.log(v)} />
+      <KanbanBoard
+        items={items}
+        setItems={setItems}
+        onItemMove={(v) => console.log(v)}
+        onColumnMove={(v) => console.log(v)}
+      />
       <button onClick={addNewItemToColumn}>Add item to column externally</button>
     </>
   );


### PR DESCRIPTION
To keep the O(1) lookups, I had decided to [create an adapter](https://github.com/clevertask/kanban-board-ui/pull/3) that received the data contract from the consumer and then adapted the input to map-based values for efficient lookups. However, that provoked the passed contract not to be kept in sync after making state changes. So, to make things in sync, I thought of converting the map-based state to the passed contract again, but that only led the flow to an infinite loop. Anyway, these changes are about keeping the passed items state as the only source of truth, converting the lookups from O(1) to O(n). Maybe in the future, we can improve this; in the meantime, things such as virtualization can help improve performance.

