### PR TITLE
chore: validate type explicitly

### DIFF
--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -466,7 +466,7 @@ export function KanbanBoard({
             ?.items.map((i) => i.id)
             .indexOf(overId);
 
-          if (!activeIndex || !overIndex) {
+          if (activeIndex === undefined || overIndex === undefined) {
             return;
           }
 


### PR DESCRIPTION
I validated whether the indexes were falsy so as not to proceed with the program flow. However, since these values are numbers so we could get `0`, that `0` was treated as a false value, disrupting the program's logic. Thus, we will explicitly validate the value type in this case.