### PR TITLE
chore: use `columns` as the main entry point name

### DIFF
--- a/src/preview/main.tsx
+++ b/src/preview/main.tsx
@@ -1,11 +1,11 @@
 import { StrictMode, useCallback, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { Items, KanbanBoard, TOnAddColumnArgs } from "../components/KanbanBoard";
+import { Columns, KanbanBoard, TOnAddColumnArgs } from "../components/KanbanBoard";
 import { removeColumnItem, updateColumnItems } from "../utils/item-state-mutations";
 import { UniqueIdentifier } from "@dnd-kit/core";
 
 function App() {
-  const [items, setItems] = useState<Items>([
+  const [columns, setColumns] = useState<Columns>([
     {
       id: "1",
       name: "A",
@@ -19,35 +19,35 @@ function App() {
   ]);
 
   const addNewItemToColumn = useCallback(() => {
-    const updateItems = updateColumnItems(items, "1", (ci) => [
+    const updateItems = updateColumnItems(columns, "1", (ci) => [
       ...ci,
       { id: Math.random().toString(), name: Math.random().toString() },
     ]);
-    setItems(updateItems);
-  }, [items]);
+    setColumns(updateItems);
+  }, [columns]);
 
   const handleOnAddColumn = (data: TOnAddColumnArgs) => {
     if (data && data.item) {
-      const updatedItems = removeColumnItem(items, data.fromContainer, data.item.id);
-      setItems(() => [
+      const updatedItems = removeColumnItem(columns, data.fromContainer, data.item.id);
+      setColumns(() => [
         ...updatedItems,
         { id: Math.random().toString(), name: Math.random().toString(), items: [data.item!] },
       ]);
     } else {
-      setItems((ci) => [...ci, { id: Math.random().toString(), name: Math.random().toString(), items: [] }]);
+      setColumns((ci) => [...ci, { id: Math.random().toString(), name: Math.random().toString(), items: [] }]);
     }
   };
 
   const handleItemRemoval = (result: { itemId: UniqueIdentifier; fromContainer: UniqueIdentifier }) => {
-    const updatedItems = removeColumnItem(items, result.fromContainer, result.itemId);
-    setItems(updatedItems);
+    const updatedItems = removeColumnItem(columns, result.fromContainer, result.itemId);
+    setColumns(updatedItems);
   };
 
   return (
     <>
       <KanbanBoard
-        items={items}
-        setItems={setItems}
+        columns={columns}
+        setColumns={setColumns}
         onColumnEdit={console.log}
         onItemMove={(v) => console.log(v)}
         onColumnMove={(v) => console.log(v)}

--- a/src/utils/item-state-mutations.ts
+++ b/src/utils/item-state-mutations.ts
@@ -1,10 +1,10 @@
 import { UniqueIdentifier } from "@dnd-kit/core";
-import { Items, DataItem } from "../components/KanbanBoard";
+import { Columns, Item } from "../components/KanbanBoard";
 
 export function updateColumnItems(
-  items: Items,
+  items: Columns,
   columnId: UniqueIdentifier,
-  updateFn: (currentState: DataItem[]) => DataItem[]
+  updateFn: (currentState: Item[]) => Item[]
 ) {
   return items.map((column) => {
     if (column.id === columnId) {
@@ -17,7 +17,7 @@ export function updateColumnItems(
   });
 }
 
-export function removeColumnItem(items: Items, columnId: UniqueIdentifier, itemId: UniqueIdentifier) {
+export function removeColumnItem(items: Columns, columnId: UniqueIdentifier, itemId: UniqueIdentifier) {
   return items.map((column) => {
     if (column.id === columnId) {
       return {
@@ -29,11 +29,11 @@ export function removeColumnItem(items: Items, columnId: UniqueIdentifier, itemI
   });
 }
 
-export function removeColumn(items: Items, columnId: UniqueIdentifier) {
+export function removeColumn(items: Columns, columnId: UniqueIdentifier) {
   return items.filter((column) => column.id !== columnId);
 }
 
-export function updateColumnName(items: Items, columnId: UniqueIdentifier, newName: string) {
+export function updateColumnName(items: Columns, columnId: UniqueIdentifier, newName: string) {
   return items.map((column) => {
     if (column.id === columnId) {
       return {


### PR DESCRIPTION
Previously, we used the names `items` and `setItems` to define the kanban board's column list along their items. That's why I think changing the name from `items` to `columns` makes sense here.