### PR TITLE
chore: use the deployment key to bypass the main write

### DIFF
--- a/.github/workflows/create-release-version.yml
+++ b/.github/workflows/create-release-version.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.CLEVERTASK_DEV_PAT }}
 
       - name: Setup Git
         run: |
@@ -28,7 +26,18 @@ jobs:
           git add package.json package-lock.json
           git commit -m "chore(release): bump version to v${{ inputs.version }}"
 
-      - name: Create Git tag
+      - name: Setup SSH for deploy key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.CLEVERTASK_DEPLOYMENT_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Set Git remote to SSH
+        run: |
+          git remote set-url origin git@github.com:${{ github.repository }}.git
+
+      - name: Create Git tag and push
         run: |
           git tag v${{ inputs.version }}
           git push origin HEAD


### PR DESCRIPTION
The action works well when releasing a version from a branch different than main; however, it doesn't work when creating a new release by triggering this action from the main branch. To "solve" this, I decided to use a deployment key, Let's see how it works 🕯️ 