### PR TITLE
Add functions to move items programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ const [columns, setColumns] = useState<Columns<{ metadata?: { foo: string } }>>(
 
 ## Helper Functions
 
+> Experimental: `moveItemToColumn`, `moveItemBefore`, `moveItemAfter`, and their `result` payload are still experimental and may change in future releases.
+
 ### `updateColumnItems`
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ A React component for rendering and managing a kanban board with drag-and-drop f
   - [removeColumnItem](#removecolumnitem)
   - [removeColumn](#removecolumn)
   - [updateColumnName](#updatecolumnname)
+  - [moveItemToColumn](#moveitemtocolumn)
+  - [moveItemBefore](#moveitembefore)
+  - [moveItemAfter](#moveitemafter)
+  - [moveColumnBefore](#movecolumnbefore)
+  - [moveColumnAfter](#movecolumnafter)
 - [Roadmap](#roadmap)
 - [Release Process](#release-process)
 - [License](#license)
@@ -229,6 +234,70 @@ updateColumnName(columns, columnId, newName);
 ```
 
 Updates a column's name.
+
+### `moveItemToColumn`
+
+```ts
+const { columns: nextColumns, result } = moveItemToColumn(
+  columns,
+  itemId,
+  targetColumnId,
+  targetIndex?,
+);
+```
+
+Moves an item to a target column. If `targetIndex` is omitted, the item is appended at the end.
+Returns:
+- `columns`: updated columns state.
+- `result`: a `MovedItemState` payload (or `null` if no movement happened).
+
+### `moveItemBefore`
+
+```ts
+const { columns: nextColumns, result } = moveItemBefore(
+  columns,
+  sourceItemId,
+  targetItemId,
+);
+```
+
+Moves an item before another item. Works within the same column or across columns.
+Returns:
+- `columns`: updated columns state.
+- `result`: a `MovedItemState` payload (or `null` if no movement happened).
+
+### `moveItemAfter`
+
+```ts
+const { columns: nextColumns, result } = moveItemAfter(
+  columns,
+  sourceItemId,
+  targetItemId,
+);
+```
+
+Moves an item after another item. Works within the same column or across columns.
+Returns:
+- `columns`: updated columns state.
+- `result`: a `MovedItemState` payload (or `null` if no movement happened).
+
+> Note: `moveItemBefore` and `moveItemAfter` assume item IDs are unique across the whole board.
+
+### `moveColumnBefore`
+
+```ts
+moveColumnBefore(columns, sourceColumnId, targetColumnId);
+```
+
+Moves a column before another column.
+
+### `moveColumnAfter`
+
+```ts
+moveColumnAfter(columns, sourceColumnId, targetColumnId);
+```
+
+Moves a column after another column.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ const [columns, setColumns] = useState<Columns<{ metadata?: { foo: string } }>>(
 | `onItemClick`  | `(itemId: UniqueIdentifier) => void`                        | `undefined`  | Callback triggered when an item on the Kanban board is clicked. Typically used to display a modal or additional item details.                                 |
 | `onAddColumn`  | `(item: TOnAddColumnArgs) => void`                          | `undefined`  | Callback triggered when a new column is added. Provides information about the added item (if applicable) or triggers an action when the drop zone is clicked. |
 | `onColumnMove` | `({newIndex: number; columnId: UniqueIdentifier;}) => void` | `undefined`  | Callback triggered when a column is moved to a new position. Provides the column's `id` and its new index.                                                    |
-| `onItemMove`   | `(result: MovedItemState) => void`                          | `undefined`  | Callback triggered when an item is moved to another column or its position changes within the same column.                                                    |
+| `onItemMove`   | `(result: MovedItemState) => void`                          | `undefined`  | Callback triggered when an item is moved to another column or its position changes within the same column. `result` can include optional `beforeItemId` and `afterItemId` for neighbor-aware ranking. |
 | `onColumnEdit` | `(columnId: UniqueIdentifier): void`                        | `undefined`  | Callback triggered when a column is clicked for editing. Provides the column's `id`.                                                                          |
 | `renderItem`   | `({ item, ... }) => React.ReactElement`                     | `undefined`  | Custom render function for items. Gives full control over layout, styling, and drag handle behavior.                                                          |
 | `renderColumn` | `({ id, label, ... }) => React.ReactElement`                | `undefined`  | Custom render function for columns. Allows full control over column layout, including drag handle and header.                                                 |
@@ -252,7 +252,7 @@ Moves an item to a target column. If `targetIndex` is omitted, the item is appen
 Returns:
 
 - `columns`: updated columns state.
-- `result`: a `MovedItemState` payload (or `null` if no movement happened).
+- `result`: a `MovedItemState` payload (or `null` if no movement happened), including optional `beforeItemId` and `afterItemId` neighbor references.
 
 ### `moveItemBefore`
 
@@ -268,7 +268,7 @@ Moves an item before another item. Works within the same column or across column
 Returns:
 
 - `columns`: updated columns state.
-- `result`: a `MovedItemState` payload (or `null` if no movement happened).
+- `result`: a `MovedItemState` payload (or `null` if no movement happened), including optional `beforeItemId` and `afterItemId` neighbor references.
 
 ### `moveItemAfter`
 
@@ -284,25 +284,41 @@ Moves an item after another item. Works within the same column or across columns
 Returns:
 
 - `columns`: updated columns state.
-- `result`: a `MovedItemState` payload (or `null` if no movement happened).
+- `result`: a `MovedItemState` payload (or `null` if no movement happened), including optional `beforeItemId` and `afterItemId` neighbor references.
 
 > Note: `moveItemBefore` and `moveItemAfter` assume item IDs are unique across the whole board.
 
 ### `moveColumnBefore`
 
 ```ts
-moveColumnBefore(columns, sourceColumnId, targetColumnId);
+const { columns: nextColumns, result } = moveColumnBefore(
+  columns,
+  sourceColumnId,
+  targetColumnId,
+);
 ```
 
 Moves a column before another column.
+Returns:
+
+- `columns`: updated columns state.
+- `result`: column move payload (or `null` if no movement happened), including `columnId`, `newIndex`, and `beforeItemId`/`afterItemId` neighbor references.
 
 ### `moveColumnAfter`
 
 ```ts
-moveColumnAfter(columns, sourceColumnId, targetColumnId);
+const { columns: nextColumns, result } = moveColumnAfter(
+  columns,
+  sourceColumnId,
+  targetColumnId,
+);
 ```
 
 Moves a column after another column.
+Returns:
+
+- `columns`: updated columns state.
+- `result`: column move payload (or `null` if no movement happened), including `columnId`, `newIndex`, and `beforeItemId`/`afterItemId` neighbor references.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ const { columns: nextColumns, result } = moveItemToColumn(
 
 Moves an item to a target column. If `targetIndex` is omitted, the item is appended at the end.
 Returns:
+
 - `columns`: updated columns state.
 - `result`: a `MovedItemState` payload (or `null` if no movement happened).
 
@@ -263,6 +264,7 @@ const { columns: nextColumns, result } = moveItemBefore(
 
 Moves an item before another item. Works within the same column or across columns.
 Returns:
+
 - `columns`: updated columns state.
 - `result`: a `MovedItemState` payload (or `null` if no movement happened).
 
@@ -278,6 +280,7 @@ const { columns: nextColumns, result } = moveItemAfter(
 
 Moves an item after another item. Works within the same column or across columns.
 Returns:
+
 - `columns`: updated columns state.
 - `result`: a `MovedItemState` payload (or `null` if no movement happened).
 

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -137,7 +137,7 @@ const dropAnimation: DropAnimation = {
   }),
 };
 
-export type BaseItem = { id: UniqueIdentifier; name: string };
+export type BaseItem = { id: UniqueIdentifier; name?: string };
 export type Item<ExtendedProps = BaseItem> = BaseItem & ExtendedProps;
 export type Columns<T = Item> = {
   id: UniqueIdentifier;

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -242,6 +242,7 @@ export function KanbanBoard<T = Item>({
   const [movedItemState, setMovedItemState] = useState<MovedItemState | null>(
     null,
   );
+  const onItemMoveRef = useRef(onItemMove);
 
   const recentlyMovedToNewContainer = useRef(false);
   const lastOverId = useRef<UniqueIdentifier | null>(null);
@@ -377,10 +378,15 @@ export function KanbanBoard<T = Item>({
   }, [columns]);
 
   useEffect(() => {
+    onItemMoveRef.current = onItemMove;
+  }, [onItemMove]);
+
+  useEffect(() => {
     if (movedItemState && movedItemState.hasEnded) {
-      onItemMove(movedItemState);
+      onItemMoveRef.current(movedItemState);
+      setMovedItemState(null);
     }
-  }, [movedItemState, onItemMove]);
+  }, [movedItemState]);
 
   return (
     <DndContext
@@ -430,18 +436,22 @@ export function KanbanBoard<T = Item>({
             return;
           }
 
-          const activeItems = activeColumn.items;
-          const overItems = overColumn.items;
+          const activeItems = [...activeColumn.items];
+          const overItems = [...overColumn.items];
 
           const overIndex = overItems.findIndex(({ id }) => id === overId);
           const activeIndex = activeItems.findIndex(
             ({ id }) => id === active.id,
           );
 
+          if (activeIndex < 0) {
+            return;
+          }
+
           let newIndex: number;
 
           if (columns.some((i) => i.id === overId)) {
-            newIndex = overItems.length + 1;
+            newIndex = overItems.length;
           } else {
             const isBelowOverItem =
               over &&
@@ -451,8 +461,7 @@ export function KanbanBoard<T = Item>({
 
             const modifier = isBelowOverItem ? 1 : 0;
 
-            newIndex =
-              overIndex >= 0 ? overIndex + modifier : overItems.length + 1;
+            newIndex = overIndex >= 0 ? overIndex + modifier : overItems.length;
           }
 
           recentlyMovedToNewContainer.current = true;
@@ -477,7 +486,12 @@ export function KanbanBoard<T = Item>({
                 };
               } else if (column.id === overContainer) {
                 const newItems = [...overItems];
-                const [movedItem] = activeItems.splice(activeIndex, 1);
+                const movedItem = activeItems[activeIndex];
+
+                if (!movedItem) {
+                  return column;
+                }
+
                 newItems.splice(newIndex, 0, movedItem);
                 return {
                   ...column,
@@ -544,12 +558,19 @@ export function KanbanBoard<T = Item>({
             ?.items.map((i) => i.id)
             .indexOf(active.id);
 
-          const overIndex = columns
-            .find((i) => i.id === overContainer)
-            ?.items.map((i) => i.id)
-            .indexOf(overId);
+          const overContainerItems =
+            columns.find((i) => i.id === overContainer)?.items || [];
+          const overIndex = columns.some((i) => i.id === overId)
+            ? overContainerItems.findIndex((item) => item.id === active.id)
+            : overContainerItems.map((i) => i.id).indexOf(overId);
 
-          if (activeIndex === undefined || overIndex === undefined) {
+          if (
+            activeIndex === undefined ||
+            overIndex === undefined ||
+            activeIndex < 0 ||
+            overIndex < 0
+          ) {
+            setActiveId(null);
             return;
           }
 
@@ -591,13 +612,15 @@ export function KanbanBoard<T = Item>({
 
           // It applies when an item is moved from one column to another but, for
           // some reason, keeps the same index it had on the previous column:
-          setMovedItemState(
-            (cs) =>
-              cs && {
-                ...cs,
-                hasEnded: true,
-              },
-          );
+          if (activeIndex === overIndex) {
+            setMovedItemState(
+              (cs) =>
+                cs && {
+                  ...cs,
+                  hasEnded: true,
+                },
+            );
+          }
         }
 
         setActiveId(null);

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -141,7 +141,7 @@ export type BaseItem = { id: UniqueIdentifier; name: string };
 export type Item<ExtendedProps = BaseItem> = BaseItem & ExtendedProps;
 export type Columns<T = Item> = {
   id: UniqueIdentifier;
-  name: string;
+  name?: string;
   items: Item<T>[];
   metadata?: any;
 }[];

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -159,6 +159,8 @@ export interface MovedItemState {
   sourceColumnId: UniqueIdentifier;
   targetColumnId: UniqueIdentifier;
   hasEnded: boolean;
+  beforeItemId?: UniqueIdentifier | null;
+  afterItemId?: UniqueIdentifier | null;
 }
 export type ColumnRenderArgs = {
   id: UniqueIdentifier;
@@ -358,6 +360,16 @@ export function KanbanBoard<T = Item>({
 
     const column = columns.find((col) => col.id === containerId);
     return column ? column.items.findIndex((item) => item.id === id) : -1;
+  };
+
+  const getAdjacentItemIds = (
+    items: { id: UniqueIdentifier }[],
+    index: number,
+  ) => {
+    return {
+      beforeItemId: items[index - 1]?.id ?? null,
+      afterItemId: items[index + 1]?.id ?? null,
+    };
   };
 
   const onDragCancel = () => {
@@ -575,6 +587,12 @@ export function KanbanBoard<T = Item>({
           }
 
           if (activeIndex !== overIndex) {
+            const reorderedItems = arrayMove(
+              overContainerItems,
+              activeIndex,
+              overIndex,
+            );
+
             setMovedItemState(
               (cs) =>
                 cs && {
@@ -583,25 +601,17 @@ export function KanbanBoard<T = Item>({
                   newIndex: overIndex,
                   targetColumnId: overContainer,
                   hasEnded: true,
+                  ...getAdjacentItemIds(reorderedItems, overIndex),
                 },
             );
 
             setColumns((items) =>
               items.map((item) => {
                 if (item.id === overContainer) {
-                  const currentContainerItems = items.find(
-                    (i) => i.id === overContainer,
-                  )?.items;
-                  if (currentContainerItems) {
-                    return {
-                      ...item,
-                      items: arrayMove(
-                        currentContainerItems,
-                        activeIndex,
-                        overIndex,
-                      ),
-                    };
-                  }
+                  return {
+                    ...item,
+                    items: reorderedItems,
+                  };
                 }
                 return item;
               }),
@@ -617,7 +627,11 @@ export function KanbanBoard<T = Item>({
               (cs) =>
                 cs && {
                   ...cs,
+                  itemId: active.id,
+                  newIndex: overIndex,
+                  targetColumnId: overContainer,
                   hasEnded: true,
+                  ...getAdjacentItemIds(overContainerItems, overIndex),
                 },
             );
           }

--- a/src/preview/main.tsx
+++ b/src/preview/main.tsx
@@ -7,6 +7,11 @@ import {
 } from "../components/KanbanBoard";
 import {
   removeColumnItem,
+  moveColumnAfter,
+  moveColumnBefore,
+  moveItemAfter,
+  moveItemBefore,
+  moveItemToColumn,
   updateColumnItems,
 } from "../utils/item-state-mutations";
 import { UniqueIdentifier } from "@dnd-kit/core";
@@ -16,42 +21,68 @@ function App() {
     Columns<{ metadata?: { foo: string } }>
   >([
     {
-      id: "1",
-      name: "A",
-      items: [{ id: "12", name: "A2" }],
-      metadata: { columnId: 4 },
+      id: "todo",
+      name: "To Do",
+      items: [
+        { id: "task-1", name: "Write API contract", metadata: { foo: "A" } },
+        { id: "task-2", name: "Create mobile modal", metadata: { foo: "B" } },
+      ],
+      metadata: { columnId: 1 },
     },
     {
-      id: "21",
-      name: "A2212",
-      items: [{ id: "12asdasda", name: "asA2", metadata: { foo: "2" } }],
-      metadata: { columnId: 222 },
+      id: "in-progress",
+      name: "In Progress",
+      items: [
+        { id: "task-3", name: "Implement helpers", metadata: { foo: "C" } },
+        { id: "task-4", name: "Connect UI buttons", metadata: { foo: "D" } },
+      ],
+      metadata: { columnId: 2 },
+    },
+    {
+      id: "qa",
+      name: "QA",
+      items: [],
+      metadata: { columnId: 3 },
+    },
+    {
+      id: "done",
+      name: "Done",
+      items: [{ id: "task-5", name: "Ship docs", metadata: { foo: "E" } }],
+      metadata: { columnId: 4 },
     },
   ]);
 
   const addNewItemToColumn = useCallback(() => {
-    const updateItems = updateColumnItems(columns, "1", (ci) => [
-      ...ci,
-      { id: Math.random().toString(), name: Math.random().toString() },
-    ]);
-    setColumns(updateItems);
-  }, [columns]);
+    setColumns((currentColumns) =>
+      updateColumnItems(currentColumns, "todo", (currentItems) => [
+        ...currentItems,
+        {
+          id: `task-${Math.random().toString(36).slice(2, 8)}`,
+          name: "Added externally",
+          metadata: { foo: "NEW" },
+        },
+      ]),
+    );
+  }, []);
 
   const handleOnAddColumn = (data: TOnAddColumnArgs) => {
+    console.log(data);
     if (data && data.item) {
-      const updatedItems = removeColumnItem(
-        columns,
-        data.fromContainer,
-        data.item.id,
-      );
-      setColumns(() => [
-        ...updatedItems,
-        {
-          id: Math.random().toString(),
-          name: Math.random().toString(),
-          items: [data.item!],
-        },
-      ]);
+      setColumns((currentColumns) => {
+        const updatedItems = removeColumnItem(
+          currentColumns,
+          data.fromContainer,
+          data.item.id,
+        );
+        return [
+          ...updatedItems,
+          {
+            id: Math.random().toString(),
+            name: Math.random().toString(),
+            items: [data.item],
+          },
+        ];
+      });
     } else {
       setColumns((ci) => [
         ...ci,
@@ -68,13 +99,87 @@ function App() {
     itemId: UniqueIdentifier;
     fromContainer: UniqueIdentifier;
   }) => {
-    const updatedItems = removeColumnItem(
-      columns,
-      result.fromContainer,
-      result.itemId,
+    setColumns((currentColumns) =>
+      removeColumnItem(currentColumns, result.fromContainer, result.itemId),
     );
-    setColumns(updatedItems);
   };
+
+  const moveTask4BeforeTask2 = useCallback(() => {
+    setColumns((currentColumns) => {
+      const { columns: nextColumns, result } = moveItemBefore(
+        currentColumns,
+        "task-4",
+        "task-2",
+      );
+      console.log("moveItemBefore result", result);
+      return nextColumns;
+    });
+  }, []);
+
+  const moveTask1AfterTask5 = useCallback(() => {
+    setColumns((currentColumns) => {
+      const { columns: nextColumns, result } = moveItemAfter(
+        currentColumns,
+        "task-1",
+        "task-5",
+      );
+      console.log("moveItemAfter result", result);
+      return nextColumns;
+    });
+  }, []);
+
+  const moveTask2ToQaTop = useCallback(() => {
+    setColumns((currentColumns) => {
+      const { columns: nextColumns, result } = moveItemToColumn(
+        currentColumns,
+        "task-2",
+        "qa",
+        0,
+      );
+      console.log("moveItemToColumn result", result);
+      return nextColumns;
+    });
+  }, []);
+
+  const moveDoneBeforeTodo = useCallback(() => {
+    setColumns((currentColumns) =>
+      moveColumnBefore(currentColumns, "done", "todo"),
+    );
+  }, []);
+
+  const moveTodoAfterInProgress = useCallback(() => {
+    setColumns((currentColumns) =>
+      moveColumnAfter(currentColumns, "todo", "in-progress"),
+    );
+  }, []);
+
+  const createBlockedAndMoveTask3 = useCallback(() => {
+    setColumns((currentColumns) => {
+      const blockedColumnId = "blocked";
+      const hasBlockedColumn = currentColumns.some(
+        (column) => column.id === blockedColumnId,
+      );
+      const withBlockedColumn = hasBlockedColumn
+        ? currentColumns
+        : [
+            ...currentColumns,
+            {
+              id: blockedColumnId,
+              name: "Blocked",
+              items: [],
+              metadata: { columnId: 999 },
+            },
+          ];
+
+      const { columns: nextColumns, result } = moveItemToColumn(
+        withBlockedColumn,
+        "task-3",
+        blockedColumnId,
+      );
+      console.log("createBlockedAndMoveTask3 result", result);
+      return nextColumns;
+    });
+  }, []);
 
   return (
     <>
@@ -139,9 +244,34 @@ function App() {
           );
         }}
       />
-      <button onClick={addNewItemToColumn}>
-        Add item to column externally
-      </button>
+      <div
+        style={{
+          display: "grid",
+          gap: "0.5rem",
+          gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+          padding: "0 20px 20px",
+        }}
+      >
+        <button onClick={addNewItemToColumn}>Add item to To Do</button>
+        <button onClick={moveTask4BeforeTask2}>
+          moveItemBefore(task-4, task-2)
+        </button>
+        <button onClick={moveTask1AfterTask5}>
+          moveItemAfter(task-1, task-5)
+        </button>
+        <button onClick={moveTask2ToQaTop}>
+          moveItemToColumn(task-2, qa, 0)
+        </button>
+        <button onClick={moveDoneBeforeTodo}>
+          moveColumnBefore(done, todo)
+        </button>
+        <button onClick={moveTodoAfterInProgress}>
+          moveColumnAfter(todo, in-progress)
+        </button>
+        <button onClick={createBlockedAndMoveTask3}>
+          Create "Blocked" + move task-3
+        </button>
+      </div>
     </>
   );
 }

--- a/src/preview/main.tsx
+++ b/src/preview/main.tsx
@@ -142,15 +142,27 @@ function App() {
   }, []);
 
   const moveDoneBeforeTodo = useCallback(() => {
-    setColumns((currentColumns) =>
-      moveColumnBefore(currentColumns, "done", "todo"),
-    );
+    setColumns((currentColumns) => {
+      const { columns: nextColumns, result } = moveColumnBefore(
+        currentColumns,
+        "done",
+        "todo",
+      );
+      console.log("moveColumnBefore result", result);
+      return nextColumns;
+    });
   }, []);
 
   const moveTodoAfterInProgress = useCallback(() => {
-    setColumns((currentColumns) =>
-      moveColumnAfter(currentColumns, "todo", "in-progress"),
-    );
+    setColumns((currentColumns) => {
+      const { columns: nextColumns, result } = moveColumnAfter(
+        currentColumns,
+        "todo",
+        "in-progress",
+      );
+      console.log("moveColumnAfter result", result);
+      return nextColumns;
+    });
   }, []);
 
   const createBlockedAndMoveTask3 = useCallback(() => {

--- a/src/utils/item-state-mutations.ts
+++ b/src/utils/item-state-mutations.ts
@@ -6,6 +6,16 @@ export type ItemMoveMutationResult<T> = {
   columns: Columns<T>;
   result: MovedItemState | null;
 };
+export type ColumnMoveState = {
+  columnId: UniqueIdentifier;
+  newIndex: number;
+  beforeItemId: UniqueIdentifier | null;
+  afterItemId: UniqueIdentifier | null;
+};
+export type ColumnMoveMutationResult<T> = {
+  columns: Columns<T>;
+  result: ColumnMoveState | null;
+};
 
 export function updateColumnItems<T>(
   items: Columns<T>,
@@ -80,6 +90,26 @@ function clampIndex(index: number, max: number) {
   return Math.max(0, Math.min(index, max));
 }
 
+function getAdjacentItemIds<T>(
+  items: ColumnItem<T>[],
+  index: number,
+): Pick<MovedItemState, "beforeItemId" | "afterItemId"> {
+  return {
+    beforeItemId: items[index - 1]?.id ?? null,
+    afterItemId: items[index + 1]?.id ?? null,
+  };
+}
+
+function getAdjacentColumnIds<T>(
+  columns: Columns<T>,
+  index: number,
+): Pick<ColumnMoveState, "beforeItemId" | "afterItemId"> {
+  return {
+    beforeItemId: columns[index - 1]?.id ?? null,
+    afterItemId: columns[index + 1]?.id ?? null,
+  };
+}
+
 /**
  * Moves an item to a given column and inserts it at `targetIndex`.
  *
@@ -150,6 +180,7 @@ export function moveItemToColumn<T>(
         targetColumnId: targetColumnId,
         newIndex: insertionIndex,
         hasEnded: true,
+        ...getAdjacentItemIds(sourceItems, insertionIndex),
       },
     };
   }
@@ -188,6 +219,7 @@ export function moveItemToColumn<T>(
       targetColumnId: targetColumnId,
       newIndex: insertionIndex,
       hasEnded: true,
+      ...getAdjacentItemIds(targetItems, insertionIndex),
     },
   };
 }
@@ -265,23 +297,32 @@ function moveColumnRelative<T>(
   sourceColumnId: UniqueIdentifier,
   targetColumnId: UniqueIdentifier,
   position: "before" | "after",
-) {
+): ColumnMoveMutationResult<T> {
   if (sourceColumnId === targetColumnId) {
-    return columns;
+    return {
+      columns,
+      result: null,
+    };
   }
 
   const sourceIndex = columns.findIndex((column) => column.id === sourceColumnId);
   const targetIndex = columns.findIndex((column) => column.id === targetColumnId);
 
   if (sourceIndex === -1 || targetIndex === -1) {
-    return columns;
+    return {
+      columns,
+      result: null,
+    };
   }
 
   const updatedColumns = [...columns];
   const [sourceColumn] = updatedColumns.splice(sourceIndex, 1);
 
   if (!sourceColumn) {
-    return columns;
+    return {
+      columns,
+      result: null,
+    };
   }
 
   const newTargetIndex = updatedColumns.findIndex(
@@ -289,7 +330,10 @@ function moveColumnRelative<T>(
   );
 
   if (newTargetIndex === -1) {
-    return columns;
+    return {
+      columns,
+      result: null,
+    };
   }
 
   const insertionIndex =
@@ -297,7 +341,14 @@ function moveColumnRelative<T>(
 
   updatedColumns.splice(insertionIndex, 0, sourceColumn);
 
-  return updatedColumns;
+  return {
+    columns: updatedColumns,
+    result: {
+      columnId: sourceColumnId,
+      newIndex: insertionIndex,
+      ...getAdjacentColumnIds(updatedColumns, insertionIndex),
+    },
+  };
 }
 
 /**
@@ -307,7 +358,7 @@ export function moveColumnBefore<T>(
   columns: Columns<T>,
   sourceColumnId: UniqueIdentifier,
   targetColumnId: UniqueIdentifier,
-) {
+): ColumnMoveMutationResult<T> {
   return moveColumnRelative(columns, sourceColumnId, targetColumnId, "before");
 }
 
@@ -318,6 +369,6 @@ export function moveColumnAfter<T>(
   columns: Columns<T>,
   sourceColumnId: UniqueIdentifier,
   targetColumnId: UniqueIdentifier,
-) {
+): ColumnMoveMutationResult<T> {
   return moveColumnRelative(columns, sourceColumnId, targetColumnId, "after");
 }

--- a/src/utils/item-state-mutations.ts
+++ b/src/utils/item-state-mutations.ts
@@ -1,10 +1,16 @@
 import { UniqueIdentifier } from "@dnd-kit/core";
-import { Columns, Item } from "../components/KanbanBoard";
+import type { Columns, MovedItemState } from "../components/KanbanBoard";
 
-export function updateColumnItems(
-  items: Columns,
+type ColumnItem<T> = Columns<T>[number]["items"][number];
+export type ItemMoveMutationResult<T> = {
+  columns: Columns<T>;
+  result: MovedItemState | null;
+};
+
+export function updateColumnItems<T>(
+  items: Columns<T>,
   columnId: UniqueIdentifier,
-  updateFn: (currentState: Item[]) => Item[]
+  updateFn: (currentState: ColumnItem<T>[]) => ColumnItem<T>[],
 ) {
   return items.map((column) => {
     if (column.id === columnId) {
@@ -17,7 +23,11 @@ export function updateColumnItems(
   });
 }
 
-export function removeColumnItem(items: Columns, columnId: UniqueIdentifier, itemId: UniqueIdentifier) {
+export function removeColumnItem<T>(
+  items: Columns<T>,
+  columnId: UniqueIdentifier,
+  itemId: UniqueIdentifier,
+) {
   return items.map((column) => {
     if (column.id === columnId) {
       return {
@@ -29,11 +39,15 @@ export function removeColumnItem(items: Columns, columnId: UniqueIdentifier, ite
   });
 }
 
-export function removeColumn(items: Columns, columnId: UniqueIdentifier) {
+export function removeColumn<T>(items: Columns<T>, columnId: UniqueIdentifier) {
   return items.filter((column) => column.id !== columnId);
 }
 
-export function updateColumnName(items: Columns, columnId: UniqueIdentifier, newName: string) {
+export function updateColumnName<T>(
+  items: Columns<T>,
+  columnId: UniqueIdentifier,
+  newName: string,
+) {
   return items.map((column) => {
     if (column.id === columnId) {
       return {
@@ -43,4 +57,267 @@ export function updateColumnName(items: Columns, columnId: UniqueIdentifier, new
     }
     return column;
   });
+}
+
+function findItemLocation<T>(
+  columns: Columns<T>,
+  itemId: UniqueIdentifier,
+): { columnIndex: number; itemIndex: number } | null {
+  for (let columnIndex = 0; columnIndex < columns.length; columnIndex++) {
+    const itemIndex = columns[columnIndex].items.findIndex(
+      (item) => item.id === itemId,
+    );
+
+    if (itemIndex !== -1) {
+      return { columnIndex, itemIndex };
+    }
+  }
+
+  return null;
+}
+
+function clampIndex(index: number, max: number) {
+  return Math.max(0, Math.min(index, max));
+}
+
+/**
+ * Moves an item to a given column and inserts it at `targetIndex`.
+ *
+ * - `targetIndex` is interpreted against the target column before mutation.
+ * - When omitted, the item is appended to the end of the target column.
+ */
+export function moveItemToColumn<T>(
+  columns: Columns<T>,
+  itemId: UniqueIdentifier,
+  targetColumnId: UniqueIdentifier,
+  targetIndex?: number,
+): ItemMoveMutationResult<T> {
+  const sourceLocation = findItemLocation(columns, itemId);
+  const targetColumnIndex = columns.findIndex(
+    (column) => column.id === targetColumnId,
+  );
+
+  if (!sourceLocation || targetColumnIndex === -1) {
+    return {
+      columns,
+      result: null,
+    };
+  }
+
+  const sourceColumn = columns[sourceLocation.columnIndex];
+  const sourceItems = [...sourceColumn.items];
+  const [movedItem] = sourceItems.splice(sourceLocation.itemIndex, 1);
+
+  if (!movedItem) {
+    return {
+      columns,
+      result: null,
+    };
+  }
+
+  if (sourceLocation.columnIndex === targetColumnIndex) {
+    let insertionIndex = targetIndex ?? sourceItems.length;
+
+    if (
+      targetIndex !== undefined &&
+      sourceLocation.itemIndex < insertionIndex
+    ) {
+      insertionIndex -= 1;
+    }
+
+    insertionIndex = clampIndex(insertionIndex, sourceItems.length);
+
+    if (insertionIndex === sourceLocation.itemIndex) {
+      return {
+        columns,
+        result: null,
+      };
+    }
+
+    sourceItems.splice(insertionIndex, 0, movedItem);
+
+    const nextColumns = columns.map((column, index) =>
+      index === sourceLocation.columnIndex
+        ? { ...column, items: sourceItems }
+        : column,
+    );
+
+    return {
+      columns: nextColumns,
+      result: {
+        itemId,
+        sourceColumnId: sourceColumn.id,
+        targetColumnId: targetColumnId,
+        newIndex: insertionIndex,
+        hasEnded: true,
+      },
+    };
+  }
+
+  const targetItems = [...columns[targetColumnIndex].items];
+  const insertionIndex = clampIndex(
+    targetIndex ?? targetItems.length,
+    targetItems.length,
+  );
+
+  targetItems.splice(insertionIndex, 0, movedItem);
+
+  const nextColumns = columns.map((column, index) => {
+    if (index === sourceLocation.columnIndex) {
+      return {
+        ...column,
+        items: sourceItems,
+      };
+    }
+
+    if (index === targetColumnIndex) {
+      return {
+        ...column,
+        items: targetItems,
+      };
+    }
+
+    return column;
+  });
+
+  return {
+    columns: nextColumns,
+    result: {
+      itemId,
+      sourceColumnId: sourceColumn.id,
+      targetColumnId: targetColumnId,
+      newIndex: insertionIndex,
+      hasEnded: true,
+    },
+  };
+}
+
+/**
+ * Moves `sourceItemId` before `targetItemId`.
+ */
+export function moveItemBefore<T>(
+  columns: Columns<T>,
+  sourceItemId: UniqueIdentifier,
+  targetItemId: UniqueIdentifier,
+): ItemMoveMutationResult<T> {
+  if (sourceItemId === targetItemId) {
+    return {
+      columns,
+      result: null,
+    };
+  }
+
+  const targetLocation = findItemLocation(columns, targetItemId);
+
+  if (!targetLocation) {
+    return {
+      columns,
+      result: null,
+    };
+  }
+
+  const targetColumnId = columns[targetLocation.columnIndex].id;
+
+  return moveItemToColumn(
+    columns,
+    sourceItemId,
+    targetColumnId,
+    targetLocation.itemIndex,
+  );
+}
+
+/**
+ * Moves `sourceItemId` after `targetItemId`.
+ */
+export function moveItemAfter<T>(
+  columns: Columns<T>,
+  sourceItemId: UniqueIdentifier,
+  targetItemId: UniqueIdentifier,
+): ItemMoveMutationResult<T> {
+  if (sourceItemId === targetItemId) {
+    return {
+      columns,
+      result: null,
+    };
+  }
+
+  const targetLocation = findItemLocation(columns, targetItemId);
+
+  if (!targetLocation) {
+    return {
+      columns,
+      result: null,
+    };
+  }
+
+  const targetColumnId = columns[targetLocation.columnIndex].id;
+
+  return moveItemToColumn(
+    columns,
+    sourceItemId,
+    targetColumnId,
+    targetLocation.itemIndex + 1,
+  );
+}
+
+function moveColumnRelative<T>(
+  columns: Columns<T>,
+  sourceColumnId: UniqueIdentifier,
+  targetColumnId: UniqueIdentifier,
+  position: "before" | "after",
+) {
+  if (sourceColumnId === targetColumnId) {
+    return columns;
+  }
+
+  const sourceIndex = columns.findIndex((column) => column.id === sourceColumnId);
+  const targetIndex = columns.findIndex((column) => column.id === targetColumnId);
+
+  if (sourceIndex === -1 || targetIndex === -1) {
+    return columns;
+  }
+
+  const updatedColumns = [...columns];
+  const [sourceColumn] = updatedColumns.splice(sourceIndex, 1);
+
+  if (!sourceColumn) {
+    return columns;
+  }
+
+  const newTargetIndex = updatedColumns.findIndex(
+    (column) => column.id === targetColumnId,
+  );
+
+  if (newTargetIndex === -1) {
+    return columns;
+  }
+
+  const insertionIndex =
+    position === "before" ? newTargetIndex : newTargetIndex + 1;
+
+  updatedColumns.splice(insertionIndex, 0, sourceColumn);
+
+  return updatedColumns;
+}
+
+/**
+ * Moves `sourceColumnId` before `targetColumnId`.
+ */
+export function moveColumnBefore<T>(
+  columns: Columns<T>,
+  sourceColumnId: UniqueIdentifier,
+  targetColumnId: UniqueIdentifier,
+) {
+  return moveColumnRelative(columns, sourceColumnId, targetColumnId, "before");
+}
+
+/**
+ * Moves `sourceColumnId` after `targetColumnId`.
+ */
+export function moveColumnAfter<T>(
+  columns: Columns<T>,
+  sourceColumnId: UniqueIdentifier,
+  targetColumnId: UniqueIdentifier,
+) {
+  return moveColumnRelative(columns, sourceColumnId, targetColumnId, "after");
 }


### PR DESCRIPTION
This PR adds experimental functions to move items programatically. Also, we added the `afterItemId` and `beforeItemId` properties when sorting an item. This is useful for recalculating the item's new value when using a lexicographical approach.


No breaking changes were added.