### PR TITLE
chore: align release automation with our shared workflow standard

### DIFF
--- a/.github/workflows/create-release-version.yml
+++ b/.github/workflows/create-release-version.yml
@@ -1,57 +1,26 @@
-name: Create Stable Release
+name: Create Release Version
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release (e.g. 1.2.3)"
+        description: "Version to release (for example 0.1.0 or 1.0.0-alpha.0)"
         required: true
+        type: string
+      prerelease:
+        description: "Mark the GitHub release as a prerelease"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-
-      - name: Install pnpm
-        run: npm install -g pnpm
-
-      - name: Setup Git
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "github-actions@clevertask.ai"
-
-      - name: Bump version in package.json
-        run: |
-          pnpm version ${{ inputs.version }} --no-git-tag-version
-          git add package.json pnpm-lock.yaml
-          git commit -m "chore(release): bump version to v${{ inputs.version }}"
-
-      - name: Setup SSH for deploy key
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.CLEVERTASK_DEPLOYMENT_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-
-      - name: Set Git remote to SSH
-        run: |
-          git remote set-url origin git@github.com:${{ github.repository }}.git
-
-      - name: Create Git tag and push
-        run: |
-          git tag v${{ inputs.version }}
-          git push origin HEAD
-          git push origin v${{ inputs.version }}
-
-      - name: Create GitHub Release with notes
-        env:
-          GH_TOKEN: ${{ secrets.CLEVERTASK_PAT }}
-        run: |
-          gh release create v${{ inputs.version }} \
-            --title "v${{ inputs.version }}" \
-            --generate-notes
+    uses: clevertask/clevertask-public-workflows/.github/workflows/create-release-version.yml@main
+    with:
+      version: ${{ inputs.version }}
+      prerelease: ${{ inputs.prerelease }}
+    secrets:
+      github_pat: ${{ secrets.CLEVERTASK_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,39 +2,22 @@ name: Publish Package
 
 on:
   workflow_dispatch:
-  release:
-    types: [created]
-  push:
-    tags:
-      - "v*"
+    inputs:
+      dist_tag:
+        description: "npm dist-tag to publish under"
+        required: true
+        default: latest
+        type: choice
+        options:
+          - latest
+          - next
 
 permissions:
-  id-token: write # Required for OIDC
+  id-token: write
   contents: read
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version-file: .nvmrc
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install pnpm
-        run: npm install -g pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run formatting check
-        run: pnpm run fmt:check
-
-      - name: Build lib
-        run: pnpm build
-
-      - name: Publish lib
-        run: pnpm publish
+    uses: clevertask/clevertask-public-workflows/.github/workflows/publish-npm.yml@main
+    with:
+      dist_tag: ${{ inputs.dist_tag }}


### PR DESCRIPTION
## Why

This repo was still using an older, repo-local release/publish setup while our current standard lives in the shared public workflows.

Aligning it with the shared approach we already use in `scribe` helps us:
- keep release automation consistent across libraries
- reduce drift and duplicated maintenance in repo-specific workflow files
- remove the obsolete SSH deploy-key path now that `CLEVERTASK_PAT` is the only auth we need

## Context

This keeps the repo on the same release/publish pattern we want to maintain going forward, with the shared workflows as the source of truth.
