### PR TITLE
Expose adjacent column ids so kanban column moves can be persisted without index-based reordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ const [columns, setColumns] = useState<Columns<{ metadata?: { foo: string } }>>(
 | `onItemRemove` | `(result: TOnItemRemoveArgs) => void`                       | `undefined`  | Callback triggered after an item has been dropped into the trashable drop zone. Provides the `itemId` and source column.                                                                              |
 | `onItemClick`  | `(itemId: UniqueIdentifier) => void`                        | `undefined`  | Callback triggered when an item on the Kanban board is clicked. Typically used to display a modal or additional item details.                                                                         |
 | `onAddColumn`  | `(item: TOnAddColumnArgs) => void`                          | `undefined`  | Callback triggered when a new column is added. Provides information about the added item (if applicable) or triggers an action when the drop zone is clicked.                                         |
-| `onColumnMove` | `({newIndex: number; columnId: UniqueIdentifier;}) => void` | `undefined`  | Callback triggered when a column is moved to a new position. Provides the column's `id` and its new index.                                                                                            |
+| `onColumnMove` | `(result: { columnId: UniqueIdentifier; newIndex: number; previousColumnId: UniqueIdentifier \| null; nextColumnId: UniqueIdentifier \| null; }) => void` | `undefined`  | Callback triggered when a column is moved to a new position. Provides the column's `id`, its new index, and the adjacent columns after the move.                                                     |
 | `onItemMove`   | `(result: MovedItemState) => void`                          | `undefined`  | Callback triggered when an item is moved to another column or its position changes within the same column. `result` can include optional `beforeItemId` and `afterItemId` for neighbor-aware ranking. |
 | `onColumnEdit` | `(columnId: UniqueIdentifier): void`                        | `undefined`  | Callback triggered when a column is clicked for editing. Provides the column's `id`.                                                                                                                  |
 | `renderItem`   | `({ item, ... }) => React.ReactElement`                     | `undefined`  | Custom render function for items. Gives full control over layout, styling, and drag handle behavior.                                                                                                  |
@@ -288,7 +288,7 @@ Moves a column before another column.
 Returns:
 
 - `columns`: updated columns state.
-- `result`: column move payload (or `null` if no movement happened), including `columnId`, `newIndex`, and `beforeItemId`/`afterItemId` neighbor references.
+- `result`: column move payload (or `null` if no movement happened), including `columnId`, `newIndex`, and `previousColumnId`/`nextColumnId` neighbor references.
 
 ### `moveColumnAfter`
 
@@ -300,7 +300,7 @@ Moves a column after another column.
 Returns:
 
 - `columns`: updated columns state.
-- `result`: column move payload (or `null` if no movement happened), including `columnId`, `newIndex`, and `beforeItemId`/`afterItemId` neighbor references.
+- `result`: column move payload (or `null` if no movement happened), including `columnId`, `newIndex`, and `previousColumnId`/`nextColumnId` neighbor references.
 
 ---
 

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -34,6 +34,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { coordinateGetter as multipleContainersCoordinateGetter } from "../utils/multipleContainerKeyboardCoordinates";
+import type { ColumnMoveState } from "../utils/item-state-mutations";
 import { Item } from "./Item";
 import { Container, ContainerProps } from "./Container";
 import { ItemProps } from "./Item/Item";
@@ -176,7 +177,7 @@ export interface Props<ExtendedItem = Item> {
   }): React.CSSProperties;
   wrapperStyle?(args: { index: number }): React.CSSProperties;
   onItemMove(result: MovedItemState): void;
-  onColumnMove?(result: { newIndex: number; columnId: UniqueIdentifier }): void;
+  onColumnMove?(result: ColumnMoveState): void;
   onAddColumn?(item: TOnAddColumnArgs): void;
   onColumnEdit?(columnId: UniqueIdentifier): void;
   onItemClick?(itemId: UniqueIdentifier): void;
@@ -490,8 +491,21 @@ export function KanbanBoard<T = Item>({
           const activeIndex = columns.map(({ id }) => id).indexOf(active.id);
           const overIndex = columns.map(({ id }) => id).indexOf(over.id);
 
-          onColumnMove?.({ newIndex: overIndex, columnId: active.id });
-          setColumns((containers) => arrayMove(containers, activeIndex, overIndex));
+          if (activeIndex === -1 || overIndex === -1 || activeIndex === overIndex) {
+            setActiveId(null);
+            return;
+          }
+
+          const nextColumns = arrayMove(columns, activeIndex, overIndex);
+
+          onColumnMove?.({
+            newIndex: overIndex,
+            columnId: active.id,
+            previousColumnId: nextColumns[overIndex - 1]?.id ?? null,
+            nextColumnId: nextColumns[overIndex + 1]?.id ?? null,
+          });
+          setColumns(nextColumns);
+          setActiveId(null);
           return;
         }
 

--- a/src/utils/item-state-mutations.ts
+++ b/src/utils/item-state-mutations.ts
@@ -9,8 +9,8 @@ export type ItemMoveMutationResult<T> = {
 export type ColumnMoveState = {
   columnId: UniqueIdentifier;
   newIndex: number;
-  beforeItemId: UniqueIdentifier | null;
-  afterItemId: UniqueIdentifier | null;
+  previousColumnId: UniqueIdentifier | null;
+  nextColumnId: UniqueIdentifier | null;
 };
 export type ColumnMoveMutationResult<T> = {
   columns: Columns<T>;
@@ -132,10 +132,10 @@ function getAdjacentItemIds<T>(
 function getAdjacentColumnIds<T>(
   columns: Columns<T>,
   index: number,
-): Pick<ColumnMoveState, "beforeItemId" | "afterItemId"> {
+): Pick<ColumnMoveState, "previousColumnId" | "nextColumnId"> {
   return {
-    beforeItemId: columns[index - 1]?.id ?? null,
-    afterItemId: columns[index + 1]?.id ?? null,
+    previousColumnId: columns[index - 1]?.id ?? null,
+    nextColumnId: columns[index + 1]?.id ?? null,
   };
 }
 


### PR DESCRIPTION
## Why

Until now, `onColumnMove` only exposed `{ columnId, newIndex }`, even though the board already knew which columns ended up immediately before and after the moved column.

That made consumers fall back to index-based persistence, which is more brittle at list boundaries and harder to align with the anchor-based `afterId` / `beforeId` move model we already use elsewhere.

This PR makes the column move payload describe the actual post-drop neighborhood, so consumers can persist the move directly from adjacent column ids instead of reconstructing intent from an index.

## What changed

- `onColumnMove` now exposes the full column move payload from [`src/components/KanbanBoard.tsx`](https://github.com/clevertask/kanban-board-ui/blob/main/src/components/KanbanBoard.tsx)
- column move neighbors were renamed from item-flavored names to `previousColumnId` / `nextColumnId` in [`src/utils/item-state-mutations.ts`](https://github.com/clevertask/kanban-board-ui/blob/main/src/utils/item-state-mutations.ts)
- the docs were updated in [`README.md`](https://github.com/clevertask/kanban-board-ui/blob/main/README.md) so the public API matches the new contract

## Outcome

Column moves now expose the information consumers actually need to persist ordering safely and clearly, while keeping item move payloads unchanged.