### PR TITLE
Add configurable drag activation constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A React component for rendering and managing a kanban board with drag-and-drop f
 
 - [Installation](#installation)
 - [Usage](#usage)
+- [Experimental Drag Activation Constraints](#experimental-drag-activation-constraints)
 - [Custom Components](#custom-components)
   - [Custom Item Rendering (`renderItem`)](#custom-item-rendering-renderitem)
   - [Custom Column Rendering (`renderColumn`)](#custom-column-rendering-rendercolumn)
@@ -69,6 +70,46 @@ function App() {
 ```
 
 Use `dragOverlayPortalContainer` when your custom `renderItem` or `renderColumn` relies on styles or CSS variables from a specific app subtree, such as a Radix `Theme` wrapper. When omitted, the drag overlay is portaled to `document.body`.
+
+---
+
+## Experimental Drag Activation Constraints
+
+`dragActivationConstraints` lets consumers tune when mouse and touch drags become active. The defaults are tuned to reduce accidental drag activation while scrolling on touch devices:
+
+```ts
+{
+  mouse: { distance: 6 },
+  touch: { delay: 220, tolerance: 8 },
+}
+```
+
+The prop is optional. If `mouse` or `touch` is omitted, the default for that input type is used. Pass `null` to disable a default constraint, or pass a dnd-kit activation constraint object to override it.
+
+```tsx
+<KanbanBoard
+  columns={columns}
+  setColumns={setColumns}
+  dragActivationConstraints={{
+    mouse: { distance: 8 },
+    touch: { delay: 260, tolerance: 10 },
+  }}
+  onItemMove={handleItemMove}
+/>
+```
+
+```tsx
+<KanbanBoard
+  columns={columns}
+  setColumns={setColumns}
+  dragActivationConstraints={{
+    mouse: null,
+  }}
+  onItemMove={handleItemMove}
+/>
+```
+
+This API is experimental while the package still uses the legacy `@dnd-kit/core` sensor API. It may be refined if the package migrates to the modern dnd-kit PointerSensor API.
 
 ---
 
@@ -200,6 +241,7 @@ const [columns, setColumns] = useState<Columns<{ metadata?: { foo: string } }>>(
 | `renderItem`                 | `({ item, ... }) => React.ReactElement`                                                                                                                   | `undefined`     | Custom render function for items. Gives full control over layout, styling, and drag handle behavior.                                                                                                  |
 | `renderColumn`               | `({ id, label, ... }) => React.ReactElement`                                                                                                              | `undefined`     | Custom render function for columns. Allows full control over column layout, including drag handle and header.                                                                                         |
 | `dragOverlayPortalContainer` | `Element \| DocumentFragment \| null`                                                                                                                     | `document.body` | Optional DOM container for the drag overlay portal. Useful when custom rendered items or columns must stay inside a themed or styled subtree.                                                         |
+| `dragActivationConstraints`  | `{ mouse?: MouseSensorOptions["activationConstraint"] \| null; touch?: TouchSensorOptions["activationConstraint"] \| null; }`                            | See above       | Experimental drag activation constraints for mouse and touch sensors. Omit an input type to use its default, pass `null` to disable its default, or pass a constraint object to override it.          |
 
 ---
 

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -12,7 +12,9 @@ import {
   getFirstCollision,
   KeyboardSensor,
   MouseSensor,
+  MouseSensorOptions,
   TouchSensor,
+  TouchSensorOptions,
   Modifiers,
   useDroppable,
   UniqueIdentifier,
@@ -130,6 +132,17 @@ export type Columns<T = Item> = {
   items: Item<T>[];
   metadata?: any;
 }[];
+export type KanbanBoardDragActivationConstraints = {
+  /**
+   * Mouse activation constraint. Use null to disable the default mouse constraint.
+   */
+  mouse?: MouseSensorOptions["activationConstraint"] | null;
+
+  /**
+   * Touch activation constraint. Use null to disable the default touch constraint.
+   */
+  touch?: TouchSensorOptions["activationConstraint"] | null;
+};
 export type TOnAddColumnArgs = {
   item: Item | null;
   fromContainer: UniqueIdentifier;
@@ -170,6 +183,12 @@ export interface Props<ExtendedItem = Item> {
    * Defaults to document.body when omitted.
    */
   dragOverlayPortalContainer?: Element | DocumentFragment | null;
+  /**
+   * Optional drag activation constraints for pointer-based sensors.
+   * Defaults to a small mouse distance and a short touch hold so scroll gestures do not
+   * accidentally start a drag.
+   */
+  dragActivationConstraints?: KanbanBoardDragActivationConstraints;
   coordinateGetter?: KeyboardCoordinateGetter;
   getItemStyles?(args: {
     value: UniqueIdentifier;
@@ -204,6 +223,10 @@ export interface Props<ExtendedItem = Item> {
 export const TRASH_ID = "void";
 const PLACEHOLDER_ID = "placeholder";
 const empty: UniqueIdentifier[] = [];
+const defaultDragActivationConstraints = {
+  mouse: { distance: 6 },
+  touch: { delay: 220, tolerance: 8 },
+} satisfies Required<KanbanBoardDragActivationConstraints>;
 
 export function KanbanBoard<T = Item>({
   columns,
@@ -230,6 +253,7 @@ export function KanbanBoard<T = Item>({
   onColumnEdit,
   onItemClick,
   dragOverlayPortalContainer,
+  dragActivationConstraints,
 }: Props<T>) {
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
   const [movedItemState, setMovedItemState] = useState<MovedItemState | null>(null);
@@ -308,9 +332,22 @@ export function KanbanBoard<T = Item>({
     [activeId, columns],
   );
   const [clonedColumns, setClonedColumns] = useState<Columns<T> | null>(null);
+  const resolvedMouseActivationConstraint =
+    dragActivationConstraints?.mouse === undefined
+      ? defaultDragActivationConstraints.mouse
+      : dragActivationConstraints.mouse;
+  const resolvedTouchActivationConstraint =
+    dragActivationConstraints?.touch === undefined
+      ? defaultDragActivationConstraints.touch
+      : dragActivationConstraints.touch;
+
   const sensors = useSensors(
-    useSensor(MouseSensor),
-    useSensor(TouchSensor),
+    useSensor(MouseSensor, {
+      activationConstraint: resolvedMouseActivationConstraint ?? undefined,
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: resolvedTouchActivationConstraint ?? undefined,
+    }),
     useSensor(KeyboardSensor, {
       coordinateGetter,
     }),


### PR DESCRIPTION
## Why

Mobile scroll gestures can accidentally start drag interactions when the first touch lands on a card or column drag handle. The board should require a more deliberate touch drag while keeping mouse and keyboard interaction responsive.

## How

- Adds a `dragActivationConstraints` prop to the public `KanbanBoard` API.
- Applies constraints to the existing `MouseSensor` and `TouchSensor`.
- Defaults mouse dragging to `{ distance: 6 }` and touch dragging to `{ delay: 220, tolerance: 8 }`.
- Keeps keyboard dragging and the existing coordinate getter unchanged.

## Scope

- Public prop/type addition for board drag activation constraints.
- No card, column, movement, or rendering semantics changed.