### PR TITLE
chore: allow pnpm dependency builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+strictDepBuilds: true
+
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Why

The publish workflow started failing after pnpm's stricter dependency-build defaults because `esbuild` needs to run its install/build script and the package did not have a workspace build allowlist.

`react-sortable-tree` already uses the same pnpm workspace config successfully, so this mirrors that setup in `kanban-board-ui`.

## What Changed

- Added `pnpm-workspace.yaml`.
- Enabled `strictDepBuilds`.
- Allowed `esbuild` in `allowBuilds`.

## What This Does Not Change

- No runtime code changes.
- No dependency version changes.
- No package API changes.

## Validation

- `pnpm install`
- `pnpm exec oxfmt --check pnpm-workspace.yaml`
- `pnpm build`
- `git diff --check`
