### PR TITLE
Add Kanban e2e contract tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+playwright-report
+test-results
 *.local
 
 # Editor directories and files

--- a/e2e/kanban.spec.ts
+++ b/e2e/kanban.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "@playwright/test";
+import {
+  dragKanbanColumn,
+  dragKanbanItem,
+  expectColumnBefore,
+  expectItemBefore,
+  expectItemInColumn,
+  expectItemNotInColumn,
+  getKanbanItem,
+} from "./utils";
+
+test.afterEach(async ({ page }) => {
+  await page.getByRole("button", { name: "Reset board", exact: true }).click();
+});
+
+test("Item can be reordered within its column after drag and drop", async ({ page }) => {
+  await page.goto("/");
+
+  await dragKanbanItem({
+    page,
+    expect,
+    from: { name: "Create mobile modal" },
+    to: { item: "Write API contract", position: "before" },
+  });
+
+  await expectItemBefore(page, expect, "Create mobile modal", "Write API contract", {
+    column: "To Do",
+  });
+  await expectItemInColumn(page, expect, "Create mobile modal", "To Do");
+});
+
+test("Item can move to another non-empty column after drag and drop", async ({ page }) => {
+  await page.goto("/");
+
+  await dragKanbanItem({
+    page,
+    expect,
+    from: { name: "Write API contract" },
+    to: { item: "Ship docs", position: "after" },
+  });
+
+  await expectItemInColumn(page, expect, "Write API contract", "Done");
+  await expectItemNotInColumn(page, expect, "Write API contract", "To Do");
+  await expectItemBefore(page, expect, "Ship docs", "Write API contract", {
+    column: "Done",
+  });
+});
+
+test("Item can move into an empty column after drag and drop", async ({ page }) => {
+  await page.goto("/");
+
+  await dragKanbanItem({
+    page,
+    expect,
+    from: { name: "Create mobile modal" },
+    to: { column: "QA", position: "inside" },
+  });
+
+  await expectItemInColumn(page, expect, "Create mobile modal", "QA");
+  await expectItemNotInColumn(page, expect, "Create mobile modal", "To Do");
+});
+
+test("Column can be reordered after drag and drop", async ({ page }) => {
+  await page.goto("/");
+
+  await dragKanbanColumn({
+    page,
+    expect,
+    from: { name: "Done" },
+    to: { column: "To Do", position: "before" },
+  });
+
+  await expectColumnBefore(page, expect, "Done", "To Do");
+});
+
+test("Item can be removed by dragging it to trash", async ({ page }) => {
+  await page.goto("/");
+
+  await dragKanbanItem({
+    page,
+    expect,
+    from: { name: "Implement helpers" },
+    to: { trash: true },
+  });
+
+  await expect(getKanbanItem(page, "Implement helpers")).toHaveCount(0);
+});

--- a/e2e/utils/drag-kanban-column.ts
+++ b/e2e/utils/drag-kanban-column.ts
@@ -1,0 +1,47 @@
+import type { Expect, Locator, Page } from "@playwright/test";
+import { getKanbanColumn, getKanbanColumnDragHandle } from "./get-kanban-column";
+
+type DragBounds = { x: number; y: number; width: number; height: number };
+
+export interface DragKanbanColumnOptions {
+  page: Page;
+  expect: Expect;
+  from: { name: string };
+  to: { column: string; position?: "before" | "after" };
+}
+
+async function getBounds(locator: Locator): Promise<DragBounds> {
+  const bounds = await locator.boundingBox();
+
+  if (!bounds) {
+    throw new Error("Could not determine bounds for drag operation");
+  }
+
+  return bounds;
+}
+
+export async function dragKanbanColumn({ page, expect, from, to }: DragKanbanColumnOptions) {
+  const fromHandle = getKanbanColumnDragHandle(page, from.name);
+  const targetColumn = getKanbanColumn(page, to.column);
+
+  await expect(fromHandle).toBeVisible();
+  await expect(targetColumn).toBeVisible();
+
+  const fromBox = await getBounds(fromHandle);
+  const targetBox = await getBounds(targetColumn);
+  const startX = fromBox.x + fromBox.width / 2;
+  const startY = fromBox.y + fromBox.height / 2;
+  const endX =
+    to.position === "after" ? targetBox.x + targetBox.width - 8 : targetBox.x + 8 + fromBox.width;
+  const endY = targetBox.y + fromBox.height / 2;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + 1, startY + 1);
+  await page.mouse.move(endX, endY, { steps: 12 });
+  await page.evaluate(() => new Promise(requestAnimationFrame));
+  await page.waitForTimeout(120);
+  await page.mouse.up();
+  await page.waitForTimeout(120);
+  await expect(getKanbanColumn(page, from.name)).toHaveCount(1);
+}

--- a/e2e/utils/drag-kanban-item.ts
+++ b/e2e/utils/drag-kanban-item.ts
@@ -1,0 +1,141 @@
+import type { Expect, Locator, Page } from "@playwright/test";
+import { getKanbanAddColumnPlaceholder, getKanbanColumn } from "./get-kanban-column";
+import { getKanbanItem, getKanbanItemDragHandle } from "./get-kanban-item";
+
+type DragBounds = { x: number; y: number; width: number; height: number };
+type ItemTarget = { item: string; position: "before" | "after" };
+type ColumnTarget = { column: string; position?: "top" | "bottom" | "inside" };
+type TrashTarget = { trash: true };
+type AddColumnTarget = { addColumnPlaceholder: true };
+type DragItemTarget = ItemTarget | ColumnTarget | TrashTarget | AddColumnTarget;
+
+export interface DragKanbanItemOptions {
+  page: Page;
+  expect: Expect;
+  from: { name: string };
+  to: DragItemTarget;
+}
+
+async function getBounds(locator: Locator): Promise<DragBounds> {
+  await locator.scrollIntoViewIfNeeded();
+
+  const bounds = await locator.boundingBox();
+
+  if (!bounds) {
+    throw new Error("Could not determine bounds for drag operation");
+  }
+
+  return bounds;
+}
+
+async function getItemDropCoordinates(
+  page: Page,
+  expect: Expect,
+  fromBox: DragBounds,
+  target: ItemTarget,
+) {
+  const targetItem = getKanbanItem(page, target.item);
+
+  await expect(targetItem).toBeVisible();
+
+  const targetBox = await getBounds(targetItem);
+  const paddingY = 4;
+  const draggingUp = fromBox.y > targetBox.y;
+  const endX = targetBox.x + targetBox.width / 2;
+  let endY =
+    target.position === "before"
+      ? targetBox.y + paddingY
+      : targetBox.y + targetBox.height - paddingY;
+
+  if (draggingUp) {
+    endY += fromBox.height;
+  }
+
+  return { x: endX, y: endY };
+}
+
+async function getColumnDropCoordinates(
+  page: Page,
+  expect: Expect,
+  target: ColumnTarget | AddColumnTarget,
+) {
+  const targetColumn =
+    "addColumnPlaceholder" in target
+      ? getKanbanAddColumnPlaceholder(page)
+      : getKanbanColumn(page, target.column);
+
+  await expect(targetColumn).toBeVisible();
+
+  const targetBox = await getBounds(targetColumn);
+  const position = "position" in target ? (target.position ?? "inside") : "inside";
+  const endX = targetBox.x + targetBox.width / 2;
+  let endY = targetBox.y + targetBox.height / 2;
+
+  if (position === "top") {
+    endY = targetBox.y + 24;
+  }
+
+  if (position === "bottom") {
+    endY = targetBox.y + targetBox.height - 24;
+  }
+
+  return { x: endX, y: endY };
+}
+
+async function getTrashDropCoordinates(page: Page, expect: Expect) {
+  const target = page.getByText("Drop here to delete", { exact: true });
+
+  await expect(target).toBeVisible();
+
+  const targetBox = await getBounds(target);
+
+  return {
+    x: targetBox.x + targetBox.width / 2,
+    y: targetBox.y + targetBox.height / 2,
+  };
+}
+
+async function getDropCoordinates(
+  page: Page,
+  expect: Expect,
+  fromBox: DragBounds,
+  target: DragItemTarget,
+) {
+  if ("item" in target) {
+    return getItemDropCoordinates(page, expect, fromBox, target);
+  }
+
+  if ("trash" in target) {
+    return getTrashDropCoordinates(page, expect);
+  }
+
+  return getColumnDropCoordinates(page, expect, target);
+}
+
+export async function dragKanbanItem({ page, expect, from, to }: DragKanbanItemOptions) {
+  const fromHandle = getKanbanItemDragHandle(page, from.name);
+
+  await expect(fromHandle).toBeVisible();
+
+  const fromBox = await getBounds(fromHandle);
+  const resolvedTarget = "trash" in to ? null : await getDropCoordinates(page, expect, fromBox, to);
+  const startX = fromBox.x + fromBox.width / 2;
+  const startY = fromBox.y + fromBox.height / 2;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + 8, startY + 8);
+  await page.evaluate(() => new Promise(requestAnimationFrame));
+
+  const target = resolvedTarget ?? (await getDropCoordinates(page, expect, fromBox, to));
+
+  await page.mouse.move(target.x, target.y, { steps: 12 });
+  await page.evaluate(() => new Promise(requestAnimationFrame));
+  await page.waitForTimeout(120);
+  await page.mouse.up();
+  await page.waitForTimeout(120);
+
+  if (!("trash" in to)) {
+    await expect(getKanbanItem(page, from.name)).toHaveCount(1);
+  }
+}

--- a/e2e/utils/expect-column-before.ts
+++ b/e2e/utils/expect-column-before.ts
@@ -1,0 +1,19 @@
+import type { Expect, Page } from "@playwright/test";
+
+export async function expectColumnBefore(
+  page: Page,
+  expect: Expect,
+  beforeLabel: string,
+  afterLabel: string,
+) {
+  const labels = await page
+    .locator("[data-kanban-column-label]")
+    .evaluateAll((nodes) => nodes.map((node) => node.textContent?.trim()));
+
+  const beforeIndex = labels.indexOf(beforeLabel);
+  const afterIndex = labels.indexOf(afterLabel);
+
+  expect(beforeIndex).toBeGreaterThanOrEqual(0);
+  expect(afterIndex).toBeGreaterThanOrEqual(0);
+  expect(beforeIndex).toBeLessThan(afterIndex);
+}

--- a/e2e/utils/expect-item-before.ts
+++ b/e2e/utils/expect-item-before.ts
@@ -1,0 +1,26 @@
+import type { Expect, Locator, Page } from "@playwright/test";
+import { getKanbanColumn } from "./get-kanban-column";
+
+async function getItemLabels(scope: Locator | Page) {
+  return scope
+    .locator("[data-kanban-item-label]")
+    .evaluateAll((nodes) => nodes.map((node) => node.textContent?.trim()));
+}
+
+export async function expectItemBefore(
+  page: Page,
+  expect: Expect,
+  beforeLabel: string,
+  afterLabel: string,
+  options?: { column?: string },
+) {
+  const scope = options?.column ? getKanbanColumn(page, options.column) : page;
+  const labels = await getItemLabels(scope);
+
+  const beforeIndex = labels.indexOf(beforeLabel);
+  const afterIndex = labels.indexOf(afterLabel);
+
+  expect(beforeIndex).toBeGreaterThanOrEqual(0);
+  expect(afterIndex).toBeGreaterThanOrEqual(0);
+  expect(beforeIndex).toBeLessThan(afterIndex);
+}

--- a/e2e/utils/expect-item-in-column.ts
+++ b/e2e/utils/expect-item-in-column.ts
@@ -1,0 +1,32 @@
+import type { Expect, Page } from "@playwright/test";
+import { getKanbanColumn } from "./get-kanban-column";
+
+export async function expectItemInColumn(
+  page: Page,
+  expect: Expect,
+  itemName: string,
+  columnName: string,
+) {
+  const column = getKanbanColumn(page, columnName);
+
+  await expect(
+    column.getByLabel(`Kanban item ${itemName}`, {
+      exact: true,
+    }),
+  ).toHaveCount(1);
+}
+
+export async function expectItemNotInColumn(
+  page: Page,
+  expect: Expect,
+  itemName: string,
+  columnName: string,
+) {
+  const column = getKanbanColumn(page, columnName);
+
+  await expect(
+    column.getByLabel(`Kanban item ${itemName}`, {
+      exact: true,
+    }),
+  ).toHaveCount(0);
+}

--- a/e2e/utils/get-kanban-column.ts
+++ b/e2e/utils/get-kanban-column.ts
@@ -1,0 +1,21 @@
+import type { Locator, Page } from "@playwright/test";
+
+export function getKanbanColumn(page: Page, name: string, options?: { exact?: boolean }): Locator {
+  return page.getByLabel(`Kanban column ${name}`, {
+    exact: options?.exact ?? true,
+  });
+}
+
+export function getKanbanColumnDragHandle(
+  page: Page,
+  name: string,
+  options?: { exact?: boolean },
+): Locator {
+  return page.getByLabel(`Drag column ${name}`, {
+    exact: options?.exact ?? true,
+  });
+}
+
+export function getKanbanAddColumnPlaceholder(page: Page): Locator {
+  return page.getByLabel("Kanban add column placeholder", { exact: true });
+}

--- a/e2e/utils/get-kanban-item.ts
+++ b/e2e/utils/get-kanban-item.ts
@@ -1,0 +1,17 @@
+import type { Locator, Page } from "@playwright/test";
+
+export function getKanbanItem(page: Page, name: string, options?: { exact?: boolean }): Locator {
+  return page.getByLabel(`Kanban item ${name}`, {
+    exact: options?.exact ?? true,
+  });
+}
+
+export function getKanbanItemDragHandle(
+  page: Page,
+  name: string,
+  options?: { exact?: boolean },
+): Locator {
+  return page.getByLabel(`Drag item ${name}`, {
+    exact: options?.exact ?? true,
+  });
+}

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -1,0 +1,7 @@
+export * from "./drag-kanban-column";
+export * from "./drag-kanban-item";
+export * from "./expect-column-before";
+export * from "./expect-item-before";
+export * from "./expect-item-in-column";
+export * from "./get-kanban-column";
+export * from "./get-kanban-item";

--- a/package.json
+++ b/package.json
@@ -16,10 +16,22 @@
   ],
   "type": "module",
   "main": "./dist/kanban-board-ui.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/kanban-board-ui.js"
+    },
+    "./e2e": {
+      "types": "./dist/e2e/utils/index.d.ts",
+      "default": "./dist/e2e/index.js"
+    }
+  },
   "scripts": {
     "dev": "vite",
-    "build": "rm -rf dist && vite build && tsc -p tsconfig.types.json --noCheck",
+    "e2e": "playwright test",
+    "e2e:dev": "playwright test --ui",
+    "build": "rm -rf dist && vite build && vite build -c vite.test.config.ts && tsc -p tsconfig.types.json --noCheck",
     "lint": "eslint .",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
@@ -35,6 +47,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: "html",
+  use: {
+    baseURL: "http://127.0.0.1:5174",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1920, height: 1080 },
+      },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev --host 127.0.0.1 --port 5174",
+    port: 5174,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.0)
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.61.0
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -520,6 +523,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@radix-ui/react-icons@1.3.2':
     resolution: {integrity: sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==}
     peerDependencies:
@@ -880,6 +888,11 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1081,6 +1094,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
@@ -1596,6 +1619,10 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.42.0':
     optional: true
 
+  '@playwright/test@1.61.0':
+    dependencies:
+      playwright: 1.61.0
+
   '@radix-ui/react-icons@1.3.2(react@19.2.5)':
     dependencies:
       react: 19.2.5
@@ -1964,6 +1991,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2133,6 +2163,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.9:
     dependencies:

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -798,10 +798,11 @@ export function KanbanBoard<T = Item>({
     if (renderColumn) {
       return renderColumn({
         id: column.id,
-        label: column.name,
+        label: column.name ?? String(column.id),
+        columnMetadata: column.metadata,
         children,
-        ref: null,
-        listeners: {},
+        ref: undefined,
+        dragListeners: {},
         attributes: {},
         style: {
           height: "100%",
@@ -809,13 +810,14 @@ export function KanbanBoard<T = Item>({
         },
         isDragging: true,
         isOver: false,
+        isColumnPlaceholder: false,
         onEdit: undefined,
       });
     }
 
     return (
       <Container
-        label={column.name}
+        label={column.name ?? String(column.id)}
         style={{
           height: "100%",
         }}

--- a/src/preview/main.tsx
+++ b/src/preview/main.tsx
@@ -1,6 +1,13 @@
+/* eslint-disable react-refresh/only-export-components */
+
 import { StrictMode, useCallback, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { Columns, KanbanBoard, TOnAddColumnArgs } from "../components/KanbanBoard";
+import {
+  type Columns,
+  KanbanBoard,
+  type MovedItemState,
+  type TOnAddColumnArgs,
+} from "../components/KanbanBoard";
 import {
   removeColumnItem,
   moveColumnAfter,
@@ -9,11 +16,26 @@ import {
   moveItemBefore,
   moveItemToColumn,
   updateColumnItems,
+  type ColumnMoveState,
 } from "../utils/item-state-mutations";
-import { UniqueIdentifier } from "@dnd-kit/core";
+import type { UniqueIdentifier } from "@dnd-kit/core";
 
-function App() {
-  const [columns, setColumns] = useState<Columns<{ metadata?: { foo: string } }>>([
+type PreviewItemFields = { metadata?: { foo: string } };
+type PreviewColumns = Columns<PreviewItemFields>;
+type ItemRemoveResult = {
+  itemId: UniqueIdentifier;
+  fromContainer: UniqueIdentifier;
+};
+type LastEvent =
+  | { type: "addItem"; result: { itemId: UniqueIdentifier; targetColumnId: UniqueIdentifier } }
+  | { type: "addColumn"; result: TOnAddColumnArgs }
+  | { type: "itemMove"; result: MovedItemState }
+  | { type: "columnMove"; result: ColumnMoveState }
+  | { type: "itemRemove"; result: ItemRemoveResult }
+  | { type: "programmaticMove"; label: string; result: unknown };
+
+function createBaseColumns(): PreviewColumns {
+  return [
     {
       id: "todo",
       name: "To Do",
@@ -44,102 +66,137 @@ function App() {
       items: [{ id: "task-5", name: "Ship docs", metadata: { foo: "E" } }],
       metadata: { columnId: 4 },
     },
-  ]);
+  ];
+}
+
+function App() {
+  const [columns, setColumns] = useState<PreviewColumns>(() => createBaseColumns());
+  const [lastEvent, setLastEvent] = useState<LastEvent | null>(null);
+  const [nextAddedItemNumber, setNextAddedItemNumber] = useState(1);
+  const [nextAddedColumnNumber, setNextAddedColumnNumber] = useState(1);
+
+  const resetBoard = useCallback(() => {
+    setColumns(createBaseColumns());
+    setLastEvent(null);
+    setNextAddedItemNumber(1);
+    setNextAddedColumnNumber(1);
+  }, []);
 
   const addNewItemToColumn = useCallback(() => {
+    const itemNumber = nextAddedItemNumber;
+    const itemId = `task-added-${itemNumber}`;
+
+    setNextAddedItemNumber(itemNumber + 1);
+    setLastEvent({
+      type: "addItem",
+      result: { itemId, targetColumnId: "todo" },
+    });
     setColumns((currentColumns) =>
       updateColumnItems(currentColumns, "todo", (currentItems) => [
         ...currentItems,
         {
-          id: `task-${Math.random().toString(36).slice(2, 8)}`,
-          name: "Added externally",
+          id: itemId,
+          name: `Added externally ${itemNumber}`,
           metadata: { foo: "NEW" },
         },
       ]),
     );
-  }, []);
+  }, [nextAddedItemNumber]);
 
   const handleOnAddColumn = (data: TOnAddColumnArgs) => {
-    console.log(data);
-    if (data && data.item) {
+    const columnNumber = nextAddedColumnNumber;
+    const nextColumn = {
+      id: `added-column-${columnNumber}`,
+      name: `Added Column ${columnNumber}`,
+      metadata: { columnId: 1000 + columnNumber },
+    };
+
+    setNextAddedColumnNumber(columnNumber + 1);
+    setLastEvent({ type: "addColumn", result: data });
+
+    if (data?.item) {
+      const movedItem = data.item as PreviewColumns[number]["items"][number];
+      const fromContainer = data.fromContainer;
+
       setColumns((currentColumns) => {
-        const updatedItems = removeColumnItem(currentColumns, data.fromContainer, data.item.id);
+        const updatedItems = removeColumnItem(currentColumns, fromContainer, movedItem.id);
+
         return [
           ...updatedItems,
           {
-            id: Math.random().toString(),
-            name: Math.random().toString(),
-            items: [data.item],
+            ...nextColumn,
+            items: [movedItem],
           },
         ];
       });
     } else {
-      setColumns((ci) => [
-        ...ci,
+      setColumns((currentColumns) => [
+        ...currentColumns,
         {
-          id: Math.random().toString(),
-          name: Math.random().toString(),
+          ...nextColumn,
           items: [],
         },
       ]);
     }
   };
 
-  const handleItemRemoval = (result: {
-    itemId: UniqueIdentifier;
-    fromContainer: UniqueIdentifier;
-  }) => {
+  const handleItemRemoval = (result: ItemRemoveResult) => {
+    setLastEvent({ type: "itemRemove", result });
     setColumns((currentColumns) =>
       removeColumnItem(currentColumns, result.fromContainer, result.itemId),
     );
   };
 
+  const runProgrammaticMove = useCallback(
+    (
+      label: string,
+      moveFn: (currentColumns: PreviewColumns) => {
+        columns: PreviewColumns;
+        result: unknown;
+      },
+    ) => {
+      setColumns((currentColumns) => {
+        const { columns: nextColumns, result } = moveFn(currentColumns);
+
+        setLastEvent({ type: "programmaticMove", label, result });
+        return nextColumns;
+      });
+    },
+    [],
+  );
+
   const moveTask4BeforeTask2 = useCallback(() => {
-    setColumns((currentColumns) => {
-      const { columns: nextColumns, result } = moveItemBefore(currentColumns, "task-4", "task-2");
-      console.log("moveItemBefore result", result);
-      return nextColumns;
-    });
-  }, []);
+    runProgrammaticMove("moveItemBefore(task-4, task-2)", (currentColumns) =>
+      moveItemBefore(currentColumns, "task-4", "task-2"),
+    );
+  }, [runProgrammaticMove]);
 
   const moveTask1AfterTask5 = useCallback(() => {
-    setColumns((currentColumns) => {
-      const { columns: nextColumns, result } = moveItemAfter(currentColumns, "task-1", "task-5");
-      console.log("moveItemAfter result", result);
-      return nextColumns;
-    });
-  }, []);
+    runProgrammaticMove("moveItemAfter(task-1, task-5)", (currentColumns) =>
+      moveItemAfter(currentColumns, "task-1", "task-5"),
+    );
+  }, [runProgrammaticMove]);
 
   const moveTask2ToQaTop = useCallback(() => {
-    setColumns((currentColumns) => {
-      const { columns: nextColumns, result } = moveItemToColumn(currentColumns, "task-2", "qa", 0);
-      console.log("moveItemToColumn result", result);
-      return nextColumns;
-    });
-  }, []);
+    runProgrammaticMove("moveItemToColumn(task-2, qa, 0)", (currentColumns) =>
+      moveItemToColumn(currentColumns, "task-2", "qa", 0),
+    );
+  }, [runProgrammaticMove]);
 
   const moveDoneBeforeTodo = useCallback(() => {
-    setColumns((currentColumns) => {
-      const { columns: nextColumns, result } = moveColumnBefore(currentColumns, "done", "todo");
-      console.log("moveColumnBefore result", result);
-      return nextColumns;
-    });
-  }, []);
+    runProgrammaticMove("moveColumnBefore(done, todo)", (currentColumns) =>
+      moveColumnBefore(currentColumns, "done", "todo"),
+    );
+  }, [runProgrammaticMove]);
 
   const moveTodoAfterInProgress = useCallback(() => {
-    setColumns((currentColumns) => {
-      const { columns: nextColumns, result } = moveColumnAfter(
-        currentColumns,
-        "todo",
-        "in-progress",
-      );
-      console.log("moveColumnAfter result", result);
-      return nextColumns;
-    });
-  }, []);
+    runProgrammaticMove("moveColumnAfter(todo, in-progress)", (currentColumns) =>
+      moveColumnAfter(currentColumns, "todo", "in-progress"),
+    );
+  }, [runProgrammaticMove]);
 
   const createBlockedAndMoveTask3 = useCallback(() => {
-    setColumns((currentColumns) => {
+    runProgrammaticMove('Create "Blocked" + move task-3', (currentColumns) => {
       const blockedColumnId = "blocked";
       const hasBlockedColumn = currentColumns.some((column) => column.id === blockedColumnId);
       const withBlockedColumn = hasBlockedColumn
@@ -154,68 +211,136 @@ function App() {
             },
           ];
 
-      const { columns: nextColumns, result } = moveItemToColumn(
-        withBlockedColumn,
-        "task-3",
-        blockedColumnId,
-      );
-      console.log("createBlockedAndMoveTask3 result", result);
-      return nextColumns;
+      return moveItemToColumn(withBlockedColumn, "task-3", blockedColumnId);
     });
-  }, []);
+  }, [runProgrammaticMove]);
 
   return (
-    <>
+    <div style={{ display: "grid", gap: "1rem" }}>
       <KanbanBoard
         columns={columns}
         setColumns={setColumns}
         onColumnEdit={console.log}
-        onItemMove={(v) => console.log(v)}
-        onColumnMove={(v) => console.log(v)}
+        onItemMove={(result) => setLastEvent({ type: "itemMove", result })}
+        onColumnMove={(result) => setLastEvent({ type: "columnMove", result })}
         onAddColumn={handleOnAddColumn}
         onItemClick={console.log}
         trashable
         onItemRemove={handleItemRemoval}
         renderColumn={(props) => {
+          const label = props.label ?? String(props.id);
+
+          if (props.isColumnPlaceholder) {
+            return (
+              <section
+                ref={props.ref}
+                aria-label="Kanban add column placeholder"
+                data-kanban-add-column-placeholder
+                style={{
+                  alignItems: "center",
+                  border: "1px dashed #888",
+                  boxSizing: "border-box",
+                  display: "flex",
+                  justifyContent: "center",
+                  minHeight: "10rem",
+                  padding: "1rem",
+                  width: "14rem",
+                  ...props.style,
+                }}
+              >
+                {props.children}
+              </section>
+            );
+          }
+
           return (
-            <div
+            <section
               ref={props.ref}
+              aria-label={`Kanban column ${label}`}
+              data-kanban-column
+              data-kanban-column-id={String(props.id)}
               style={{
+                boxSizing: "border-box",
+                display: "grid",
+                gap: "0.75rem",
                 padding: "1rem",
                 width: "22rem",
                 outline: "1px solid red",
                 ...props.style,
               }}
             >
-              <button {...props.dragListeners}>Drag meeeasdee!</button>
-              <h3>{props.label}</h3>
-              <h3>{props.columnMetadata?.columnId}</h3>
-              {props.children}
-            </div>
+              <button
+                type="button"
+                {...props.attributes}
+                {...props.dragListeners}
+                aria-label={`Drag column ${label}`}
+                data-kanban-column-drag-handle
+                style={{ cursor: "grab", justifySelf: "start" }}
+              >
+                Drag column
+              </button>
+              <h3 data-kanban-column-label style={{ margin: 0 }}>
+                {label}
+              </h3>
+              <p style={{ margin: 0 }}>{props.columnMetadata?.columnId}</p>
+              <ul
+                aria-label={`Items in ${label}`}
+                style={{
+                  display: "grid",
+                  gap: "1rem",
+                  listStyle: "none",
+                  margin: 0,
+                  minHeight: "4rem",
+                  padding: 0,
+                }}
+              >
+                {props.children}
+              </ul>
+            </section>
           );
         }}
-        renderItem={({ item, dragging, onItemClick, dragListeners, ref, styleLayout }) => {
+        renderItem={({
+          item,
+          dragging,
+          dragOverlay,
+          onItemClick,
+          dragListeners,
+          ref,
+          styleLayout,
+        }) => {
+          const label = item.name ?? String(item.id);
+
           return (
             <li
               ref={ref}
+              aria-label={dragOverlay ? undefined : `Kanban item ${label}`}
+              data-kanban-item
+              data-kanban-item-id={String(item.id)}
               onClick={onItemClick}
               style={{
-                padding: "16px",
-                marginTop: "1rem",
                 backgroundColor: dragging ? "#f0f0f0" : "#fff",
                 border: "1px solid #ccc",
-                borderRadius: "24px",
+                borderRadius: "8px",
+                display: "grid",
+                gap: "0.5rem",
+                margin: 0,
+                padding: "16px",
                 ...styleLayout,
               }}
             >
-              <strong>
-                {item.name} {item.metadata?.foo}
-              </strong>
-              <button>Click me</button>
+              <strong data-kanban-item-label>{label}</strong>
+              <span>{item.metadata?.foo}</span>
+              <button type="button">Click item</button>
 
-              <div {...dragListeners} style={{ cursor: "pointer" }}>
-                Drag from here
-              </div>
+              <button
+                type="button"
+                {...dragListeners}
+                aria-label={dragOverlay ? undefined : `Drag item ${label}`}
+                data-kanban-item-drag-handle
+                style={{ cursor: "grab", justifySelf: "start" }}
+              >
+                Drag item
+              </button>
             </li>
           );
         }}
@@ -225,7 +350,7 @@ function App() {
           display: "grid",
           gap: "0.5rem",
           gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
-          padding: "0 20px 20px",
+          padding: "0 20px",
         }}
       >
         <button onClick={addNewItemToColumn}>Add item to To Do</button>
@@ -235,8 +360,18 @@ function App() {
         <button onClick={moveDoneBeforeTodo}>moveColumnBefore(done, todo)</button>
         <button onClick={moveTodoAfterInProgress}>moveColumnAfter(todo, in-progress)</button>
         <button onClick={createBlockedAndMoveTask3}>Create "Blocked" + move task-3</button>
+        <button onClick={resetBoard}>Reset board</button>
       </div>
-    </>
+      <pre
+        aria-label="Last kanban event"
+        data-kanban-last-event
+        style={{ margin: "0 20px 20px", padding: 12, border: "1px solid #ddd" }}
+      >
+        {lastEvent
+          ? JSON.stringify(lastEvent, null, 2)
+          : "Move result will appear here (programmatic or drag-and-drop)."}
+      </pre>
+    </div>
   );
 }
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,5 +21,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src", "e2e/utils"]
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -6,8 +6,8 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "declarationMap": true,
-    "rootDir": "./src",
+    "rootDir": ".",
     "outDir": "./dist"
   },
-  "include": ["src/index.ts", "src/vite-env.d.ts"]
+  "include": ["src/index.ts", "src/vite-env.d.ts", "e2e/utils/index.ts"]
 }

--- a/vite.test.config.ts
+++ b/vite.test.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, "e2e/utils/index.ts"),
+      formats: ["es"],
+      fileName: "index",
+    },
+    rollupOptions: {
+      external: ["@playwright/test"],
+    },
+    outDir: "dist/e2e",
+    emptyOutDir: false,
+  },
+});


### PR DESCRIPTION
## Why

We need confidence before upgrading `dnd-kit` to its latest version. The Kanban board behavior depends on pointer-driven drag/drop interactions that are easy to regress during dependency upgrades or internal refactors.

This PR adds an e2e contract around the package's expected drag/drop behavior so future changes can verify that item movement, column movement, empty-column drops, and trash removal still behave the way consumers rely on.

## How

- Mirror the sortable tree package's Playwright setup and helper pattern.
- Keep tests readable by hiding drag-coordinate math behind reusable e2e helpers.
- Use accessible drag labels in the preview harness so tests can use Playwright's recommended locators.
- Run the e2e suite with one worker to avoid drag/drop race conditions.
- Export the e2e utilities from the package so consumers can reuse the same drag helpers.

## What This Covers

- Adds Chromium Playwright config and `pnpm e2e` / `pnpm e2e:dev` scripts.
- Adds exported e2e helpers under `./e2e`.
- Makes the preview deterministic with stable base data, deterministic add-column/add-item ids, and a `Reset board` button.
- Adds e2e coverage for:
  - reordering an item within a column
  - moving an item to another non-empty column
  - moving an item into an empty column
  - reordering columns
  - dragging an item to trash
- Fixes the custom column drag-overlay render args so the overlay uses `dragListeners` and includes the expected render-prop fields.

## Notes For Reviewers

- The Playwright project starts with Chromium only. We can expand to Firefox/WebKit after the helper shape feels stable.
- The e2e helper API intentionally follows the sortable tree package style: tests describe behavior, helpers own pointer math.
- Full `pnpm run lint` still reports pre-existing package lint issues outside this harness. The new e2e/preview/config files pass targeted lint.

## Verification

- `pnpm e2e`
- `pnpm run build`
- `pnpm exec oxfmt --check .`
- `pnpm exec eslint e2e src/preview/main.tsx playwright.config.ts vite.test.config.ts`
