### PR TITLE
Fix add-column placeholder drops

### DIFF
--- a/e2e/kanban.spec.ts
+++ b/e2e/kanban.spec.ts
@@ -60,6 +60,30 @@ test("Item can move into an empty column after drag and drop", async ({ page }) 
   await expectItemNotInColumn(page, expect, "Create mobile modal", "To Do");
 });
 
+test("Item can move into a column created from the add-column placeholder", async ({ page }) => {
+  await page.goto("/");
+
+  await dragKanbanItem({
+    page,
+    expect,
+    from: { name: "Create mobile modal" },
+    to: { addColumnPlaceholder: true },
+  });
+
+  await expectItemInColumn(page, expect, "Create mobile modal", "Added Column 1");
+  await expectItemNotInColumn(page, expect, "Create mobile modal", "To Do");
+
+  await dragKanbanItem({
+    page,
+    expect,
+    from: { name: "Write API contract" },
+    to: { column: "Added Column 1", position: "inside" },
+  });
+
+  await expectItemInColumn(page, expect, "Write API contract", "Added Column 1");
+  await expectItemNotInColumn(page, expect, "Write API contract", "To Do");
+});
+
 test("Column can be reordered after drag and drop", async ({ page }) => {
   await page.goto("/");
 

--- a/e2e/utils/drag-kanban-item.ts
+++ b/e2e/utils/drag-kanban-item.ts
@@ -3,7 +3,7 @@ import { getKanbanAddColumnPlaceholder, getKanbanColumn } from "./get-kanban-col
 import { getKanbanItem, getKanbanItemDragHandle } from "./get-kanban-item";
 
 type DragBounds = { x: number; y: number; width: number; height: number };
-type ItemTarget = { item: string; position: "before" | "after" };
+type ItemTarget = { item: string; position: "before" | "after"; column?: string };
 type ColumnTarget = { column: string; position?: "top" | "bottom" | "inside" };
 type TrashTarget = { trash: true };
 type AddColumnTarget = { addColumnPlaceholder: true };
@@ -12,8 +12,20 @@ type DragItemTarget = ItemTarget | ColumnTarget | TrashTarget | AddColumnTarget;
 export interface DragKanbanItemOptions {
   page: Page;
   expect: Expect;
-  from: { name: string };
+  from: { name: string; column?: string };
   to: DragItemTarget;
+}
+
+function getScopedKanbanItem(page: Page, name: string, column?: string): Locator {
+  const scope = column ? getKanbanColumn(page, column) : page;
+
+  return getKanbanItem(scope, name);
+}
+
+function getScopedKanbanItemDragHandle(page: Page, name: string, column?: string): Locator {
+  const scope = column ? getKanbanColumn(page, column) : page;
+
+  return getKanbanItemDragHandle(scope, name);
 }
 
 async function getBounds(locator: Locator): Promise<DragBounds> {
@@ -34,7 +46,7 @@ async function getItemDropCoordinates(
   fromBox: DragBounds,
   target: ItemTarget,
 ) {
-  const targetItem = getKanbanItem(page, target.item);
+  const targetItem = getScopedKanbanItem(page, target.item, target.column);
 
   await expect(targetItem).toBeVisible();
 
@@ -113,7 +125,7 @@ async function getDropCoordinates(
 }
 
 export async function dragKanbanItem({ page, expect, from, to }: DragKanbanItemOptions) {
-  const fromHandle = getKanbanItemDragHandle(page, from.name);
+  const fromHandle = getScopedKanbanItemDragHandle(page, from.name, from.column);
 
   await expect(fromHandle).toBeVisible();
 
@@ -135,7 +147,7 @@ export async function dragKanbanItem({ page, expect, from, to }: DragKanbanItemO
   await page.mouse.up();
   await page.waitForTimeout(120);
 
-  if (!("trash" in to)) {
+  if (!("trash" in to) && !("addColumnPlaceholder" in to)) {
     await expect(getKanbanItem(page, from.name)).toHaveCount(1);
   }
 }

--- a/e2e/utils/get-kanban-item.ts
+++ b/e2e/utils/get-kanban-item.ts
@@ -1,17 +1,21 @@
 import type { Locator, Page } from "@playwright/test";
 
-export function getKanbanItem(page: Page, name: string, options?: { exact?: boolean }): Locator {
-  return page.getByLabel(`Kanban item ${name}`, {
+export function getKanbanItem(
+  scope: Locator | Page,
+  name: string,
+  options?: { exact?: boolean },
+): Locator {
+  return scope.getByLabel(`Kanban item ${name}`, {
     exact: options?.exact ?? true,
   });
 }
 
 export function getKanbanItemDragHandle(
-  page: Page,
+  scope: Locator | Page,
   name: string,
   options?: { exact?: boolean },
 ): Locator {
-  return page.getByLabel(`Drag item ${name}`, {
+  return scope.getByLabel(`Drag item ${name}`, {
     exact: options?.exact ?? true,
   });
 }

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -10,6 +10,7 @@ import {
   PointerSensor,
   type DragEndEvent,
   type DragOverEvent,
+  type DropAnimation,
 } from "@dnd-kit/dom";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { move } from "@dnd-kit/helpers";
@@ -49,7 +50,25 @@ type ItemStyleArgs = {
   isDragOverlay: boolean;
 };
 
-function DroppableContainer({
+type DroppableContainerBaseProps = ContainerProps & {
+  dragDisabled?: boolean;
+  id: UniqueIdentifier;
+  index: number;
+  style?: React.CSSProperties;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  columnMetadata: any;
+  renderColumn: Props["renderColumn"];
+};
+
+function DroppableContainer(props: DroppableContainerBaseProps) {
+  if (props.id === PLACEHOLDER_ID) {
+    return <AddColumnDroppableContainer {...props} />;
+  }
+
+  return <SortableDroppableContainer {...props} />;
+}
+
+function SortableDroppableContainer({
   children,
   dragDisabled,
   id,
@@ -58,23 +77,15 @@ function DroppableContainer({
   renderColumn,
   columnMetadata,
   ...props
-}: ContainerProps & {
-  dragDisabled?: boolean;
-  id: UniqueIdentifier;
-  index: number;
-  style?: React.CSSProperties;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  columnMetadata: any;
-  renderColumn: Props["renderColumn"];
-}) {
+}: DroppableContainerBaseProps) {
   const { handleRef, isDragging, isDropTarget, ref } = useSortable({
     id,
     index,
     group: COLUMN_GROUP,
     type: COLUMN_TYPE,
-    accept: id === PLACEHOLDER_ID ? ITEM_TYPE : [COLUMN_TYPE, ITEM_TYPE],
+    accept: [COLUMN_TYPE, ITEM_TYPE],
     disabled: {
-      draggable: Boolean(dragDisabled || id === PLACEHOLDER_ID),
+      draggable: Boolean(dragDisabled),
       droppable: false,
     },
     collisionPriority: CollisionPriority.Low,
@@ -113,6 +124,46 @@ function DroppableContainer({
     </Container>
   );
 }
+
+function AddColumnDroppableContainer({
+  children,
+  id,
+  style,
+  renderColumn,
+  columnMetadata,
+  ...props
+}: DroppableContainerBaseProps) {
+  const { isDropTarget, ref } = useDroppable({
+    id,
+    accept: ITEM_TYPE,
+    type: COLUMN_TYPE,
+    collisionPriority: CollisionPriority.Low,
+  });
+
+  return renderColumn ? (
+    renderColumn({
+      id,
+      label: props.label,
+      columnMetadata,
+      children,
+      ref,
+      dragListeners: {},
+      attributes: {},
+      style,
+      isDragging: false,
+      isOver: isDropTarget,
+      isColumnPlaceholder: true,
+    })
+  ) : (
+    <Container ref={ref} style={style} hover={isDropTarget} handleProps={{}} {...props}>
+      {children}
+    </Container>
+  );
+}
+
+const dropAnimation: DropAnimation = {
+  duration: 200,
+};
 
 export type BaseItem = { id: UniqueIdentifier; name?: string };
 export type Item<ExtendedProps = BaseItem> = BaseItem & ExtendedProps;
@@ -311,7 +362,7 @@ export function KanbanBoard<T = Item>({
   };
 
   const renderOverlay = (
-    <DragOverlay dropAnimation={null}>
+    <DragOverlay dropAnimation={dropAnimation}>
       {(source) =>
         source.type === COLUMN_TYPE
           ? renderContainerDragOverlay(source.id)
@@ -408,10 +459,16 @@ export function KanbanBoard<T = Item>({
           }
 
           if (target.id === PLACEHOLDER_ID) {
-            onAddColumnRef.current?.({
+            if (clonedColumnsRef.current) {
+              commitColumns(clonedColumnsRef.current);
+            }
+
+            const itemToAdd = {
               item: findItem(source.id),
               fromContainer: sourceColumnId,
-            });
+            };
+
+            onAddColumnRef.current?.(itemToAdd);
             cleanupDragState();
             return;
           }

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -10,7 +10,6 @@ import {
   PointerSensor,
   type DragEndEvent,
   type DragOverEvent,
-  type DropAnimation,
 } from "@dnd-kit/dom";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { move } from "@dnd-kit/helpers";
@@ -114,10 +113,6 @@ function DroppableContainer({
     </Container>
   );
 }
-
-const dropAnimation: DropAnimation = {
-  duration: 200,
-};
 
 export type BaseItem = { id: UniqueIdentifier; name?: string };
 export type Item<ExtendedProps = BaseItem> = BaseItem & ExtendedProps;
@@ -316,7 +311,7 @@ export function KanbanBoard<T = Item>({
   };
 
   const renderOverlay = (
-    <DragOverlay dropAnimation={dropAnimation}>
+    <DragOverlay dropAnimation={null}>
       {(source) =>
         source.type === COLUMN_TYPE
           ? renderContainerDragOverlay(source.id)


### PR DESCRIPTION
## Why
Dropping an item onto the add-column placeholder could crash React with a removeChild NotFoundError. The placeholder was registered as a sortable column even though it is only a drop target, and hover state could also leave the dragged item optimistically moved into the last real column before the add-column callback ran.

## What changed
- Render the add-column placeholder as a plain droppable target instead of a sortable column.
- Restore the drag-start column snapshot before invoking onAddColumn for placeholder drops, so consumers move the item from the original state instead of an interim hover state.
- Add E2E coverage for dropping an item onto the placeholder-created column and then moving another item into that created column.
- Extend E2E item helpers with optional column scoping.